### PR TITLE
Seek Time Optimization

### DIFF
--- a/miner/miner.cpp
+++ b/miner/miner.cpp
@@ -24,7 +24,7 @@ void Log_init(void)
 		//sprintf_s(filename, MAX_PATH, "Logs\\%02d-%02d-%02d_%02d_%02d_%02d.log", cur_time.wYear, cur_time.wMonth, cur_time.wDay, cur_time.wHour, cur_time.wMinute, cur_time.wSecond);
 		ss << "Logs\\" << cur_time.wYear << "-" << cur_time.wMonth << "-" << cur_time.wDay << "_" << cur_time.wHour << "_" << cur_time.wMinute << "_" << cur_time.wSecond << ".log";
 		std::string filename = ss.str();
-		
+
 		if ((fp_Log = _fsopen(filename.c_str(), "wt", _SH_DENYNO)) == NULL)
 		{
 			wattron(win_main, COLOR_PAIR(12));
@@ -58,31 +58,32 @@ void Log_server(char const *const strLog)
 	{
 		char * Msg_log = (char*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, len_str * 2 + 1);
 		if (Msg_log == nullptr)	ShowMemErrorExit();
-		
+
 		for (size_t i = 0, j = 0; i<len_str; i++, j++)
 		{
-			if(strLog[i] == '\r')
-			{	
-				Msg_log[j] = '\\'; 
+			if (strLog[i] == '\r')
+			{
+				Msg_log[j] = '\\';
 				j++;
-				Msg_log[j] = 'r';}
-			else 
-				if(strLog[i] == '\n') 
-				{ 
-					Msg_log[j] = '\\'; 
+				Msg_log[j] = 'r';
+			}
+			else
+				if (strLog[i] == '\n')
+				{
+					Msg_log[j] = '\\';
 					j++;
 					Msg_log[j] = 'n';
 				}
 				else
-				if (strLog[i] == '%')
-				{
-					Msg_log[j] = '%';
-					j++;
-					Msg_log[j] = '%';
-				}
-				else Msg_log[j] = strLog[i];
+					if (strLog[i] == '%')
+					{
+						Msg_log[j] = '%';
+						j++;
+						Msg_log[j] = '%';
+					}
+					else Msg_log[j] = strLog[i];
 		}
-		
+
 		fprintf_s(fp_Log, "%s", Msg_log);
 		fflush(fp_Log);
 		HeapFree(hHeap, 0, Msg_log);
@@ -121,7 +122,7 @@ void ShowMemErrorExit(void)
 int load_config(char const *const filename)
 {
 	FILE * pFile;
-	
+
 	fopen_s(&pFile, filename, "rt");
 
 	if (pFile == nullptr)
@@ -145,32 +146,32 @@ int load_config(char const *const filename)
 	fclose(pFile);
 
 	Document document;	// Default template parameter uses UTF8 and MemoryPoolAllocator.
-	if (document.Parse<0>(json_).HasParseError()){
+	if (document.Parse<0>(json_).HasParseError()) {
 		fprintf(stderr, "\nJSON format error (offset %u) check miner.conf\n%s\n", (unsigned)document.GetErrorOffset(), GetParseError_En(document.GetParseError())); //(offset %s  %s", (unsigned)document.GetErrorOffset(), (char*)document.GetParseError());
 		system("pause");
 		exit(-1);
 	}
 
-	if(document.IsObject())
+	if (document.IsObject())
 	{	// Document is a JSON value represents the root of DOM. Root can be either an object or array.
 
 		if (document.HasMember("UseLog") && (document["UseLog"].IsBool()))	use_log = document["UseLog"].GetBool();
 
 		Log_init();
 
-		if(document.HasMember("Mode") && document["Mode"].IsString())
+		if (document.HasMember("Mode") && document["Mode"].IsString())
 		{
 			Log("\nMode: ");
-			if(strcmp(document["Mode"].GetString(), "solo") == 0) miner_mode = 0;
+			if (strcmp(document["Mode"].GetString(), "solo") == 0) miner_mode = 0;
 			else miner_mode = 1;
 			Log_u(miner_mode);
 		}
 
-		Log("\nServer: "); 
+		Log("\nServer: ");
 		if (document.HasMember("Server") && document["Server"].IsString())	nodeaddr = document["Server"].GetString();//strcpy_s(nodeaddr, document["Server"].GetString());
 		Log(nodeaddr.c_str());
 
-		Log("\nPort: "); 
+		Log("\nPort: ");
 		if (document.HasMember("Port"))
 		{
 			if (document["Port"].IsString())	nodeport = document["Port"].GetString();
@@ -178,42 +179,42 @@ int load_config(char const *const filename)
 			Log(nodeport.c_str());
 		}
 
-		if(document.HasMember("Paths") && document["Paths"].IsArray()){
+		if (document.HasMember("Paths") && document["Paths"].IsArray()) {
 			const Value& Paths = document["Paths"];			// Using a reference for consecutive access is handy and faster.
 			for (SizeType i = 0; i < Paths.Size(); i++)
-			{	
+			{
 				Log("\nPath: ");
-				paths_dir.push_back(Paths[i].GetString()); 
-				Log((char*)paths_dir[i].c_str()); 
+				paths_dir.push_back(Paths[i].GetString());
+				Log((char*)paths_dir[i].c_str());
 			}
 		}
-		
+
 		Log("\nCacheSize: ");
-		if(document.HasMember("CacheSize") && (document["CacheSize"].IsUint64())) cache_size = document["CacheSize"].GetUint64();
+		if (document.HasMember("CacheSize") && (document["CacheSize"].IsUint64())) cache_size = document["CacheSize"].GetUint64();
 		Log_u(cache_size);
-		
+
 		Log("\nCacheSize2: ");
 		if (document.HasMember("CacheSize2") && (document["CacheSize2"].IsUint64())) cache_size2 = document["CacheSize2"].GetUint64();
 		Log_u(cache_size2);
 
 		Log("\nUseHDDWakeUp: ");
-		if(document.HasMember("UseHDDWakeUp") && (document["UseHDDWakeUp"].IsBool())) use_wakeup = document["UseHDDWakeUp"].GetBool();
+		if (document.HasMember("UseHDDWakeUp") && (document["UseHDDWakeUp"].IsBool())) use_wakeup = document["UseHDDWakeUp"].GetBool();
 		Log_u(use_wakeup);
 
-		Log("\nSendInterval: "); 
-		if(document.HasMember("SendInterval") && (document["SendInterval"].IsUint())) send_interval = (size_t)document["SendInterval"].GetUint();
+		Log("\nSendInterval: ");
+		if (document.HasMember("SendInterval") && (document["SendInterval"].IsUint())) send_interval = (size_t)document["SendInterval"].GetUint();
 		Log_u(send_interval);
 
-		Log("\nUpdateInterval: "); 
-		if(document.HasMember("UpdateInterval") && (document["UpdateInterval"].IsUint())) update_interval = (size_t)document["UpdateInterval"].GetUint();
+		Log("\nUpdateInterval: ");
+		if (document.HasMember("UpdateInterval") && (document["UpdateInterval"].IsUint())) update_interval = (size_t)document["UpdateInterval"].GetUint();
 		Log_u(update_interval);
 
 		Log("\nDebug: ");
-		if(document.HasMember("Debug") && (document["Debug"].IsBool()))	use_debug = document["Debug"].GetBool();
+		if (document.HasMember("Debug") && (document["Debug"].IsBool()))	use_debug = document["Debug"].GetBool();
 		Log_u(use_debug);
-				
+
 		Log("\nUpdater address: ");
-		if (document.HasMember("UpdaterAddr") && document["UpdaterAddr"].IsString()) updateraddr =document["UpdaterAddr"].GetString(); //strcpy_s(updateraddr, document["UpdaterAddr"].GetString());
+		if (document.HasMember("UpdaterAddr") && document["UpdaterAddr"].IsString()) updateraddr = document["UpdaterAddr"].GetString(); //strcpy_s(updateraddr, document["UpdaterAddr"].GetString());
 		Log(updateraddr.c_str());
 
 		Log("\nUpdater port: ");
@@ -250,7 +251,7 @@ int load_config(char const *const filename)
 		}
 		Log(proxyport.c_str());
 
-		Log("\nShowWinner: "); 
+		Log("\nShowWinner: ");
 		if (document.HasMember("ShowWinner") && (document["ShowWinner"].IsBool()))	show_winner = document["ShowWinner"].GetBool();
 		Log_u(show_winner);
 
@@ -263,7 +264,7 @@ int load_config(char const *const filename)
 		Log_u(use_boost);
 
 		Log("\nWinSizeX: ");
-		if(document.HasMember("WinSizeX") && (document["WinSizeX"].IsUint())) win_size_x = (short)document["WinSizeX"].GetUint();
+		if (document.HasMember("WinSizeX") && (document["WinSizeX"].IsUint())) win_size_x = (short)document["WinSizeX"].GetUint();
 		Log_u(win_size_x);
 
 		Log("\nWinSizeY: ");
@@ -275,17 +276,17 @@ int load_config(char const *const filename)
 		Log_u(win_size_y);
 
 #ifdef GPU_ON_C
-		Log("\nGPU_Platform: "); 
+		Log("\nGPU_Platform: ");
 		if (document.HasMember("GPU_Platform") && (document["GPU_Platform"].IsInt())) gpu_devices.use_gpu_platform = (size_t)document["GPU_Platform"].GetUint();
 		Log_llu(gpu_devices.use_gpu_platform);
-	
-		Log("\nGPU_Device: "); 
+
+		Log("\nGPU_Device: ");
 		if (document.HasMember("GPU_Device") && (document["GPU_Device"].IsInt())) gpu_devices.use_gpu_device = (size_t)document["GPU_Device"].GetUint();
 		Log_llu(gpu_devices.use_gpu_device);
 #endif	
 
 	}
-	 
+
 	Log("\n=== Config loaded ===");
 	HeapFree(hHeap, 0, json_);
 	return 1;
@@ -293,127 +294,127 @@ int load_config(char const *const filename)
 
 /*
 LPSTR DisplayErrorText( DWORD dwLastError )
-{ 
+{
 #pragma warning(suppress: 6102)
-	HMODULE hModule = nullptr; // default to system source 
-	LPSTR MessageBuffer = nullptr; 
-	DWORD dwBufferLength; 
-	DWORD dwFormatFlags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_SYSTEM ;
+HMODULE hModule = nullptr; // default to system source
+LPSTR MessageBuffer = nullptr;
+DWORD dwBufferLength;
+DWORD dwFormatFlags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_SYSTEM ;
 
-	if(dwLastError >= NERR_BASE && dwLastError <= MAX_NERR) 
-	{ 
-		hModule = LoadLibraryEx( TEXT("netmsg.dll"), nullptr, LOAD_LIBRARY_AS_DATAFILE );
-		if(hModule != nullptr) dwFormatFlags |= FORMAT_MESSAGE_FROM_HMODULE;
-	} 
-	dwBufferLength = FormatMessageA(dwFormatFlags, hModule, dwLastError, MAKELANGID(LANG_SYSTEM_DEFAULT, SUBLANG_SYS_DEFAULT), (LPSTR)&MessageBuffer, 0, nullptr);
-	if(hModule != nullptr) FreeLibrary(hModule); 
+if(dwLastError >= NERR_BASE && dwLastError <= MAX_NERR)
+{
+hModule = LoadLibraryEx( TEXT("netmsg.dll"), nullptr, LOAD_LIBRARY_AS_DATAFILE );
+if(hModule != nullptr) dwFormatFlags |= FORMAT_MESSAGE_FROM_HMODULE;
+}
+dwBufferLength = FormatMessageA(dwFormatFlags, hModule, dwLastError, MAKELANGID(LANG_SYSTEM_DEFAULT, SUBLANG_SYS_DEFAULT), (LPSTR)&MessageBuffer, 0, nullptr);
+if(hModule != nullptr) FreeLibrary(hModule);
 
-	return MessageBuffer;
+return MessageBuffer;
 }
 */
 
 // Helper routines taken from http://stackoverflow.com/questions/1557400/hex-to-char-array-in-c
-int xdigit( char const digit ){
-  int val;
-       if( '0' <= digit && digit <= '9' ) val = digit -'0';
-  else if( 'a' <= digit && digit <= 'f' ) val = digit -'a'+10;
-  else if( 'A' <= digit && digit <= 'F' ) val = digit -'A'+10;
-  else val = -1;
-  return val;
+int xdigit(char const digit) {
+	int val;
+	if ('0' <= digit && digit <= '9') val = digit - '0';
+	else if ('a' <= digit && digit <= 'f') val = digit - 'a' + 10;
+	else if ('A' <= digit && digit <= 'F') val = digit - 'A' + 10;
+	else val = -1;
+	return val;
 }
- 
+
 size_t xstr2strr(char *buf, size_t const bufsize, const char *const in) {
-  if( !in ) return 0; // missing input string
- 
-  size_t inlen = (size_t)strlen(in);
-  if( inlen%2 != 0 ) inlen--; // hex string must even sized
- 
-  size_t i,j;
-  for(i=0; i<inlen; i++ )
-    if( xdigit(in[i])<0 ) return 0; // bad character in hex string
- 
-  if( !buf || bufsize<inlen/2+1 ) return 0; // no buffer or too small
- 
-  for(i=0,j=0; i<inlen; i+=2,j++ )
-    buf[j] = xdigit(in[i])*16 + xdigit(in[i+1]);
- 
-  buf[inlen/2] = '\0';
-  return inlen/2+1;
+	if (!in) return 0; // missing input string
+
+	size_t inlen = (size_t)strlen(in);
+	if (inlen % 2 != 0) inlen--; // hex string must even sized
+
+	size_t i, j;
+	for (i = 0; i<inlen; i++)
+		if (xdigit(in[i])<0) return 0; // bad character in hex string
+
+	if (!buf || bufsize<inlen / 2 + 1) return 0; // no buffer or too small
+
+	for (i = 0, j = 0; i<inlen; i += 2, j++)
+		buf[j] = xdigit(in[i]) * 16 + xdigit(in[i + 1]);
+
+	buf[inlen / 2] = '\0';
+	return inlen / 2 + 1;
 }
 
 /*
 std::wstring str2wstr(std::string &s)
 {
-	int slen = (int)s.length() + 1;
-	size_t len = MultiByteToWideChar(CP_ACP, 0, s.c_str(), slen, 0, 0);
-	wchar_t *buf = new wchar_t[len];
-	MultiByteToWideChar(CP_ACP, 0, s.c_str(), slen, buf, (int)len);
-	std::wstring r(buf);
-	delete[] buf;
-	return r;
+int slen = (int)s.length() + 1;
+size_t len = MultiByteToWideChar(CP_ACP, 0, s.c_str(), slen, 0, 0);
+wchar_t *buf = new wchar_t[len];
+MultiByteToWideChar(CP_ACP, 0, s.c_str(), slen, buf, (int)len);
+std::wstring r(buf);
+delete[] buf;
+return r;
 }
 */
- 
+
 void GetPass(char const *const p_strFolderPath)
 {
-  FILE * pFile;
-  unsigned char * buffer;
-  size_t len_pass;
-  char * filename = (char*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, MAX_PATH);
-  if (filename == nullptr) ShowMemErrorExit();
-  sprintf_s(filename, MAX_PATH, "%s%s", p_strFolderPath, "passphrases.txt");
-  
-//  printf_s("\npass from: %s\n",filename);
-  fopen_s(&pFile, filename, "rt");
-  if (pFile==nullptr) 
-  {
-	  wattron(win_main, COLOR_PAIR(12));
-	  wprintw(win_main, "passphrases.txt not found\n", 0);
-	  wattroff(win_main, COLOR_PAIR(12));
-	  system("pause");
-	  exit (-1);
-  }
-  HeapFree(hHeap, 0, filename);
-  _fseeki64(pFile , 0 , SEEK_END);
-  size_t const lSize = _ftelli64(pFile);
-  _fseeki64(pFile, 0, SEEK_SET);
+	FILE * pFile;
+	unsigned char * buffer;
+	size_t len_pass;
+	char * filename = (char*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, MAX_PATH);
+	if (filename == nullptr) ShowMemErrorExit();
+	sprintf_s(filename, MAX_PATH, "%s%s", p_strFolderPath, "passphrases.txt");
 
-  buffer = (unsigned char*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, lSize + 1);
-  if (buffer == nullptr) ShowMemErrorExit();
-  
-  len_pass = fread(buffer, 1, lSize, pFile);
-  fclose(pFile);
-  
-  pass = (char*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, lSize * 3);
-  if (pass == nullptr) ShowMemErrorExit();
-  
-	for(size_t i=0, j=0; i<len_pass; i++, j++) 
+	//  printf_s("\npass from: %s\n",filename);
+	fopen_s(&pFile, filename, "rt");
+	if (pFile == nullptr)
+	{
+		wattron(win_main, COLOR_PAIR(12));
+		wprintw(win_main, "passphrases.txt not found\n", 0);
+		wattroff(win_main, COLOR_PAIR(12));
+		system("pause");
+		exit(-1);
+	}
+	HeapFree(hHeap, 0, filename);
+	_fseeki64(pFile, 0, SEEK_END);
+	size_t const lSize = _ftelli64(pFile);
+	_fseeki64(pFile, 0, SEEK_SET);
+
+	buffer = (unsigned char*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, lSize + 1);
+	if (buffer == nullptr) ShowMemErrorExit();
+
+	len_pass = fread(buffer, 1, lSize, pFile);
+	fclose(pFile);
+
+	pass = (char*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, lSize * 3);
+	if (pass == nullptr) ShowMemErrorExit();
+
+	for (size_t i = 0, j = 0; i<len_pass; i++, j++)
 	{
 		if ((buffer[i] == '\n') || (buffer[i] == '\r') || (buffer[i] == '\t')) j--; // Пропускаем символы, переделать buffer[i] < 20
 		else
 			if (buffer[i] == ' ') pass[j] = '+';
-			else 
+			else
 				if (isalnum(buffer[i]) == 0)
 				{
 					sprintf_s(pass + j, lSize * 3, "%%%x", (unsigned char)buffer[i]);
-					j = j+2;
+					j = j + 2;
 				}
-				else memcpy(&pass[j],&buffer[i],1);
-  }
-  //printf_s("\n%s\n",pass);
+				else memcpy(&pass[j], &buffer[i], 1);
+	}
+	//printf_s("\n%s\n",pass);
 	HeapFree(hHeap, 0, buffer);
 }
 
 size_t GetFiles(const std::string &str, std::vector <t_files> *p_files)
 {
-    HANDLE hFile = INVALID_HANDLE_VALUE;
-    WIN32_FIND_DATAA   FindFileData;
+	HANDLE hFile = INVALID_HANDLE_VALUE;
+	WIN32_FIND_DATAA   FindFileData;
 	size_t count = 0;
 	std::vector<std::string> path;
 	size_t first = 0;
 	size_t last = 0;
-	
-	do{
+
+	do {
 		last = str.find("+", first);
 		if (last == -1) last = str.length();
 		std::string str2(str.substr(first, last - first));
@@ -421,7 +422,7 @@ size_t GetFiles(const std::string &str, std::vector <t_files> *p_files)
 		path.push_back(str2);
 		first = last + 1;
 	} while (last != str.length());
-	
+
 	for (auto iter = path.begin(); iter != path.end(); ++iter)
 	{
 		hFile = FindFirstFileA(LPCSTR((*iter + "*").c_str()), &FindFileData);
@@ -448,7 +449,7 @@ size_t GetFiles(const std::string &str, std::vector <t_files> *p_files)
 									FindFileData.cFileName,
 									(((static_cast<ULONGLONG>(FindFileData.nFileSizeHigh) << (sizeof(FindFileData.nFileSizeLow) * 8)) | FindFileData.nFileSizeLow)),
 									key, nonce, nonces, stagger, p2
-								});
+									});
 								count++;
 							}
 
@@ -489,7 +490,7 @@ size_t Get_index_acc(unsigned long long const key)
 		}
 		acc_index++;
 	}
-	bests.push_back({key, 0, 0, 0, targetDeadlineInfo});
+	bests.push_back({ key, 0, 0, 0, targetDeadlineInfo });
 	LeaveCriticalSection(&bestsLock);
 	return bests.size() - 1;
 }
@@ -497,133 +498,133 @@ size_t Get_index_acc(unsigned long long const key)
 ////////////////////////
 /*
 void gen_nonce(unsigned long long addr, unsigned long long start_nonce, unsigned long long count) {
-	#define PLOT_SIZE	(4096 * 64)
-	#define HASH_SIZE	32
-	#define HASH_CAP	4096
-	#define SCOOP_SIZE	64
+#define PLOT_SIZE	(4096 * 64)
+#define HASH_SIZE	32
+#define HASH_CAP	4096
+#define SCOOP_SIZE	64
 
-	unsigned long long nonce1;
-	unsigned long long nonce2;
-	unsigned long long nonce3;
-	unsigned long long nonce4;
-	//char * final = (char *)calloc(32, 1);
-	char *final1 = new char[32];
-	char *final2 = new char[32];
-	char *final3 = new char[32];
-	char *final4 = new char[32];
+unsigned long long nonce1;
+unsigned long long nonce2;
+unsigned long long nonce3;
+unsigned long long nonce4;
+//char * final = (char *)calloc(32, 1);
+char *final1 = new char[32];
+char *final2 = new char[32];
+char *final3 = new char[32];
+char *final4 = new char[32];
 
-	char *gendata1 = new char[16 + PLOT_SIZE];
-	char *gendata2 = new char[16 + PLOT_SIZE];
-	char *gendata3 = new char[16 + PLOT_SIZE];
-	char *gendata4 = new char[16 + PLOT_SIZE];
+char *gendata1 = new char[16 + PLOT_SIZE];
+char *gendata2 = new char[16 + PLOT_SIZE];
+char *gendata3 = new char[16 + PLOT_SIZE];
+char *gendata4 = new char[16 + PLOT_SIZE];
 
-	char * cache = (char *)calloc(64 * count, 1);
-	char *xv = (char*)&addr;
-	mshabal_context *mx = new mshabal_context[sizeof(mshabal_context)];
+char * cache = (char *)calloc(64 * count, 1);
+char *xv = (char*)&addr;
+mshabal_context *mx = new mshabal_context[sizeof(mshabal_context)];
 
-	size_t len;
-	for (size_t i = 0; i < 8; i++)
-	{
-		gendata1[PLOT_SIZE + i] = xv[7 - i];
-		gendata2[PLOT_SIZE + i] = xv[7 - i];
-		gendata3[PLOT_SIZE + i] = xv[7 - i];
-		gendata4[PLOT_SIZE + i] = xv[7 - i];
-	}
+size_t len;
+for (size_t i = 0; i < 8; i++)
+{
+gendata1[PLOT_SIZE + i] = xv[7 - i];
+gendata2[PLOT_SIZE + i] = xv[7 - i];
+gendata3[PLOT_SIZE + i] = xv[7 - i];
+gendata4[PLOT_SIZE + i] = xv[7 - i];
+}
 
-	for (unsigned long long z = start_nonce; z < (start_nonce + count); z+=4) {
+for (unsigned long long z = start_nonce; z < (start_nonce + count); z+=4) {
 //		xv = (char*)&z;
 //		for (i = 8; i < 16; i++) gendata[PLOT_SIZE + i] = xv[15 - i];
 
-		nonce1 = z + 0;
-		nonce2 = z + 1;
-		nonce3 = z + 2;
-		nonce4 = z + 3;
-		char *xv1 = (char*)&nonce1;
-		char *xv2 = (char*)&nonce2;
-		char *xv3 = (char*)&nonce3;
-		char *xv4 = (char*)&nonce4;
-		for (size_t i = 8; i < 16; i++)
-		{
-			gendata1[PLOT_SIZE + i] = xv1[15 - i];
-			gendata2[PLOT_SIZE + i] = xv2[15 - i];
-			gendata3[PLOT_SIZE + i] = xv3[15 - i];
-			gendata4[PLOT_SIZE + i] = xv4[15 - i];
-		}
+nonce1 = z + 0;
+nonce2 = z + 1;
+nonce3 = z + 2;
+nonce4 = z + 3;
+char *xv1 = (char*)&nonce1;
+char *xv2 = (char*)&nonce2;
+char *xv3 = (char*)&nonce3;
+char *xv4 = (char*)&nonce4;
+for (size_t i = 8; i < 16; i++)
+{
+gendata1[PLOT_SIZE + i] = xv1[15 - i];
+gendata2[PLOT_SIZE + i] = xv2[15 - i];
+gendata3[PLOT_SIZE + i] = xv3[15 - i];
+gendata4[PLOT_SIZE + i] = xv4[15 - i];
+}
 
-		for (size_t i = PLOT_SIZE; i > 0; i -= HASH_SIZE)
-		{
-			avx1_mshabal_init(mx, 256);
-			len = PLOT_SIZE + 16 - i;
-			if (len > HASH_CAP)   len = HASH_CAP;
-			avx1_mshabal(mx, &gendata1[i], &gendata2[i], &gendata3[i], &gendata4[i], len);
-			avx1_mshabal_close(mx, 0, 0, 0, 0, 0, &gendata1[i - HASH_SIZE], &gendata2[i - HASH_SIZE], &gendata3[i - HASH_SIZE], &gendata4[i - HASH_SIZE]);
+for (size_t i = PLOT_SIZE; i > 0; i -= HASH_SIZE)
+{
+avx1_mshabal_init(mx, 256);
+len = PLOT_SIZE + 16 - i;
+if (len > HASH_CAP)   len = HASH_CAP;
+avx1_mshabal(mx, &gendata1[i], &gendata2[i], &gendata3[i], &gendata4[i], len);
+avx1_mshabal_close(mx, 0, 0, 0, 0, 0, &gendata1[i - HASH_SIZE], &gendata2[i - HASH_SIZE], &gendata3[i - HASH_SIZE], &gendata4[i - HASH_SIZE]);
 
-			// ceil because (4096*32*2-32)/64 == 4095,5 but scoop 4095 is not complete yet
-			//int scoopNumberReady = i / SCOOP_SIZE;
-			//if (i % SCOOP_SIZE)	++scoopNumberReady;
-			//if (scoopNumberReady == scoop) break;
-			if ((i / SCOOP_SIZE == scoop) && (i % SCOOP_SIZE == 0))  break;
+// ceil because (4096*32*2-32)/64 == 4095,5 but scoop 4095 is not complete yet
+//int scoopNumberReady = i / SCOOP_SIZE;
+//if (i % SCOOP_SIZE)	++scoopNumberReady;
+//if (scoopNumberReady == scoop) break;
+if ((i / SCOOP_SIZE == scoop) && (i % SCOOP_SIZE == 0))  break;
 
-		}
+}
 
 
-		//avx1_mshabal_init(mx, 256);
-		//avx1_mshabal(mx, gendata1, gendata2, gendata3, gendata4, 16 + PLOT_SIZE);
-		//avx1_mshabal_close(mx, 0, 0, 0, 0, 0, final1, final2, final3, final4);
+//avx1_mshabal_init(mx, 256);
+//avx1_mshabal(mx, gendata1, gendata2, gendata3, gendata4, 16 + PLOT_SIZE);
+//avx1_mshabal_close(mx, 0, 0, 0, 0, 0, final1, final2, final3, final4);
 
-		// XOR with final
-		for (size_t i = scoop * SCOOP_SIZE; i < scoop * SCOOP_SIZE + SCOOP_SIZE; i++)
-		{
-			gendata1[i] ^= (final1[i % 32]);
-			gendata2[i] ^= (final2[i % 32]);
-			gendata3[i] ^= (final3[i % 32]);
-			gendata4[i] ^= (final4[i % 32]);
-		}
-		gendata1[scoop * 64] ^= (final1[(scoop * 64) % HASH_SIZE]);
-		gendata2[scoop * 64] ^= (final2[(scoop * 64) % HASH_SIZE]);
-		gendata3[scoop * 64] ^= (final3[(scoop * 64) % HASH_SIZE]);
-		gendata4[scoop * 64] ^= (final4[(scoop * 64) % HASH_SIZE]);
+// XOR with final
+for (size_t i = scoop * SCOOP_SIZE; i < scoop * SCOOP_SIZE + SCOOP_SIZE; i++)
+{
+gendata1[i] ^= (final1[i % 32]);
+gendata2[i] ^= (final2[i % 32]);
+gendata3[i] ^= (final3[i % 32]);
+gendata4[i] ^= (final4[i % 32]);
+}
+gendata1[scoop * 64] ^= (final1[(scoop * 64) % HASH_SIZE]);
+gendata2[scoop * 64] ^= (final2[(scoop * 64) % HASH_SIZE]);
+gendata3[scoop * 64] ^= (final3[(scoop * 64) % HASH_SIZE]);
+gendata4[scoop * 64] ^= (final4[(scoop * 64) % HASH_SIZE]);
 
-		memmove(&cache[(z - start_nonce) * 64], &gendata1[scoop * 64], 64);
-		memmove(&cache[(z - start_nonce + 1) * 64], &gendata2[scoop * 64], 64);
-		memmove(&cache[(z - start_nonce + 2) * 64], &gendata3[scoop * 64], 64);
-		memmove(&cache[(z - start_nonce + 3) * 64], &gendata4[scoop * 64], 64);
-	}
-	//free(final);
-	//free(gendata);
-	delete[] gendata1;
-	delete[] gendata2;
-	delete[] gendata3;
-	delete[] gendata4;
-	delete[] final1;
-	delete[] final2;
-	delete[] final3;
-	delete[] final4;
-	delete[] mx;
+memmove(&cache[(z - start_nonce) * 64], &gendata1[scoop * 64], 64);
+memmove(&cache[(z - start_nonce + 1) * 64], &gendata2[scoop * 64], 64);
+memmove(&cache[(z - start_nonce + 2) * 64], &gendata3[scoop * 64], 64);
+memmove(&cache[(z - start_nonce + 3) * 64], &gendata4[scoop * 64], 64);
+}
+//free(final);
+//free(gendata);
+delete[] gendata1;
+delete[] gendata2;
+delete[] gendata3;
+delete[] gendata4;
+delete[] final1;
+delete[] final2;
+delete[] final3;
+delete[] final4;
+delete[] mx;
 
-	//acc = Get_index_acc(key);
-	//procscoop_sph(n, size, cache, 0, std::string("generator"));
-	procscoop_m_4(start_nonce, count, cache, 0, std::string("generator"));
+//acc = Get_index_acc(key);
+//procscoop_sph(n, size, cache, 0, std::string("generator"));
+procscoop_m_4(start_nonce, count, cache, 0, std::string("generator"));
 }
 
 
 void generator_i(size_t number)
 {
-	unsigned long long start_nonce = 10000000000 * (number + 1);// * (local_num + 1);
-	unsigned long long size = 1000;
-	clock_t start_work_time;
-	wprintw(win_main, "\ngenerator RUNING !");
-	while (!stopThreads)
-	{
-		start_work_time = clock();
-		gen_nonce(bests[0].account_id, start_nonce, size);
-		
-		wprintw(win_main, "\n%llu\tnoces/min: %f   (scoop %llu)", start_nonce, (float)((float)size * CLOCKS_PER_SEC * 60 / (float)(clock() - start_work_time)), scoop);
-		//wrefresh(win_main);
-		
-		start_nonce = start_nonce + size;
-	};
-	return;
+unsigned long long start_nonce = 10000000000 * (number + 1);// * (local_num + 1);
+unsigned long long size = 1000;
+clock_t start_work_time;
+wprintw(win_main, "\ngenerator RUNING !");
+while (!stopThreads)
+{
+start_work_time = clock();
+gen_nonce(bests[0].account_id, start_nonce, size);
+
+wprintw(win_main, "\n%llu\tnoces/min: %f   (scoop %llu)", start_nonce, (float)((float)size * CLOCKS_PER_SEC * 60 / (float)(clock() - start_work_time)), scoop);
+//wrefresh(win_main);
+
+start_nonce = start_nonce + size;
+};
+return;
 }
 
 */
@@ -644,7 +645,7 @@ void proxy_i(void)
 	struct addrinfo hints;
 
 	RtlSecureZeroMemory(&hints, sizeof(hints));
-	hints.ai_family = AF_INET; 
+	hints.ai_family = AF_INET;
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
 	hints.ai_flags = AI_PASSIVE;
@@ -663,7 +664,7 @@ void proxy_i(void)
 		wattroff(win_main, COLOR_PAIR(12));
 		freeaddrinfo(result);
 	}
-	
+
 	iResult = bind(ServerSocket, result->ai_addr, (int)result->ai_addrlen);
 	if (iResult == SOCKET_ERROR) {
 		wattron(win_main, COLOR_PAIR(12));
@@ -697,7 +698,7 @@ void proxy_i(void)
 		struct sockaddr_in client_socket_address;
 		int iAddrSize = sizeof(struct sockaddr_in);
 		ClientSocket = accept(ServerSocket, (struct sockaddr *)&client_socket_address, (socklen_t*)&iAddrSize);
-		
+
 		char client_address_str[INET_ADDRSTRLEN];
 		inet_ntop(hints.ai_family, &(client_socket_address.sin_addr), client_address_str, INET_ADDRSTRLEN);
 
@@ -714,7 +715,7 @@ void proxy_i(void)
 		else
 		{
 			RtlSecureZeroMemory(buffer, buffer_size);
-			do{
+			do {
 				RtlSecureZeroMemory(tmp_buffer, buffer_size);
 				iResult = recv(ClientSocket, tmp_buffer, (int)(buffer_size - 1), 0);
 				strcat_s(buffer, buffer_size, tmp_buffer);
@@ -870,21 +871,21 @@ void send_i(void)
 		for (auto iter = shares.begin(); iter != shares.end();)
 		{
 
-		//Гасим шару если она больше текущего targetDeadline, актуально для режима Proxy
-				if ((iter->best / baseTarget) > bests[Get_index_acc(iter->account_id)].targetDeadline)
+			//Гасим шару если она больше текущего targetDeadline, актуально для режима Proxy
+			if ((iter->best / baseTarget) > bests[Get_index_acc(iter->account_id)].targetDeadline)
+			{
+				if (use_debug)
 				{
-					if (use_debug)
-					{
-						_strtime_s(tbuffer);
-						wattron(win_main, COLOR_PAIR(4));
-						wprintw(win_main, "%s [%20llu]\t%llu > %llu  discarded\n", tbuffer, iter->account_id, iter->best / baseTarget, bests[Get_index_acc(iter->account_id)].targetDeadline, 0);
-						wattroff(win_main, COLOR_PAIR(4));
-					}
-					EnterCriticalSection(&sharesLock);
-					iter = shares.erase(iter);
-					LeaveCriticalSection(&sharesLock);
-					continue;
+					_strtime_s(tbuffer);
+					wattron(win_main, COLOR_PAIR(4));
+					wprintw(win_main, "%s [%20llu]\t%llu > %llu  discarded\n", tbuffer, iter->account_id, iter->best / baseTarget, bests[Get_index_acc(iter->account_id)].targetDeadline, 0);
+					wattroff(win_main, COLOR_PAIR(4));
 				}
+				EnterCriticalSection(&sharesLock);
+				iter = shares.erase(iter);
+				LeaveCriticalSection(&sharesLock);
+				continue;
+			}
 
 			RtlSecureZeroMemory(&hints, sizeof(hints));
 			hints.ai_family = AF_INET;
@@ -993,7 +994,7 @@ void send_i(void)
 				RtlSecureZeroMemory(buffer, buffer_size);
 				size_t  pos = 0;
 				iResult = 0;
-				do{
+				do {
 					iResult = recv(ConnectSocket, &buffer[pos], (int)(buffer_size - pos - 1), 0);
 					if (iResult > 0) pos += (size_t)iResult;
 				} while (iResult > 0);
@@ -1084,10 +1085,10 @@ void send_i(void)
 										wattroff(win_main, COLOR_PAIR(6));
 									}
 								}
-								else{
+								else {
 									if (answ.HasMember("errorDescription")) {
 										wattron(win_main, COLOR_PAIR(15));
-										wprintw(win_main, "[ERROR %u] %s\n", answ["errorCode"].GetInt(), answ["errorDescription"].GetString(),0);
+										wprintw(win_main, "[ERROR %u] %s\n", answ["errorCode"].GetInt(), answ["errorDescription"].GetString(), 0);
 										wattroff(win_main, COLOR_PAIR(15));
 										wattron(win_main, COLOR_PAIR(12));
 										if (answ["errorCode"].GetInt() == 1004) wprintw(win_main, "You need change reward assignment and wait 4 blocks (~16 minutes)\n"); //error 1004
@@ -1107,7 +1108,7 @@ void send_i(void)
 							{
 								_strtime_s(tbuffer);
 								deadline = bests[Get_index_acc(iter->body.account_id)].DL; //может лучше iter->deadline ?
-								// if(deadline > iter->deadline) deadline = iter->deadline;
+																						   // if(deadline > iter->deadline) deadline = iter->deadline;
 								wattron(win_main, COLOR_PAIR(10));
 								wprintw(win_main, "%s [%20llu] confirmed DL   %10llu\n", tbuffer, iter->body.account_id, iter->deadline, 0);
 								wattroff(win_main, COLOR_PAIR(10));
@@ -1163,7 +1164,7 @@ void procscoop_m_4(unsigned long long const nonce, unsigned long long const n, c
 	char sig2[32 + 64];
 	char sig3[32 + 64];
 	cache = data;
-	
+
 	memcpy(sig0, signature, 32);
 	memcpy(sig1, signature, 32);
 	memcpy(sig2, signature, 32);
@@ -1183,7 +1184,7 @@ void procscoop_m_4(unsigned long long const nonce, unsigned long long const n, c
 		memcpy(&sig1[32], &cache[(v + 1) * 64], 64);
 		memcpy(&sig2[32], &cache[(v + 2) * 64], 64);
 		memcpy(&sig3[32], &cache[(v + 3) * 64], 64);
-		
+
 		memcpy(&x, &init_x, sizeof(init_x)); // optimization: avx1_mshabal_init(&x, 256);
 		avx1_mshabal(&x, (const unsigned char*)sig0, (const unsigned char*)sig1, (const unsigned char*)sig2, (const unsigned char*)sig3, 64 + 32);
 		avx1_mshabal_close(&x, 0, 0, 0, 0, 0, res0, res1, res2, res3);
@@ -1212,26 +1213,26 @@ void procscoop_m_4(unsigned long long const nonce, unsigned long long const n, c
 
 		if ((*wertung / baseTarget) <= bests[acc].targetDeadline)
 		{
-				if (bests[acc].nonce == 0 || *wertung < bests[acc].best)
+			if (bests[acc].nonce == 0 || *wertung < bests[acc].best)
+			{
+				Log("\nfound deadline=");	Log_llu(*wertung / baseTarget); Log(" nonce=");	Log_llu(nonce + v + posn); Log(" for account: "); Log_llu(bests[acc].account_id); Log(" file: "); Log((char*)file_name.c_str());
+				EnterCriticalSection(&bestsLock);
+				bests[acc].best = *wertung;
+				bests[acc].nonce = nonce + v + posn;
+				bests[acc].DL = *wertung / baseTarget;
+				LeaveCriticalSection(&bestsLock);
+				EnterCriticalSection(&sharesLock);
+				shares.push_back({ file_name, bests[acc].account_id, bests[acc].best, bests[acc].nonce });
+				LeaveCriticalSection(&sharesLock);
+				if (use_debug)
 				{
-					Log("\nfound deadline=");	Log_llu(*wertung / baseTarget); Log(" nonce=");	Log_llu(nonce + v + posn); Log(" for account: "); Log_llu(bests[acc].account_id); Log(" file: "); Log((char*)file_name.c_str());
-					EnterCriticalSection(&bestsLock);
-					bests[acc].best = *wertung;
-					bests[acc].nonce = nonce + v + posn;
-					bests[acc].DL = *wertung / baseTarget;
-					LeaveCriticalSection(&bestsLock);
-					EnterCriticalSection(&sharesLock);
-					shares.push_back({ file_name, bests[acc].account_id, bests[acc].best, bests[acc].nonce });
-					LeaveCriticalSection(&sharesLock);
-					if (use_debug)
-					{
-						char tbuffer[9];
-						_strtime_s(tbuffer);
-						wattron(win_main, COLOR_PAIR(2));
-						wprintw(win_main, "%s [%20llu] found DL:      %9llu\n", tbuffer, bests[acc].account_id, bests[acc].DL, 0);
-						wattroff(win_main, COLOR_PAIR(2));
-					}
+					char tbuffer[9];
+					_strtime_s(tbuffer);
+					wattron(win_main, COLOR_PAIR(2));
+					wprintw(win_main, "%s [%20llu] found DL:      %9llu\n", tbuffer, bests[acc].account_id, bests[acc].DL, 0);
+					wattroff(win_main, COLOR_PAIR(2));
 				}
+			}
 		}
 	}
 }
@@ -1256,7 +1257,7 @@ void procscoop_m256_8(unsigned long long const nonce, unsigned long long const n
 	char res7[32];
 	cache = data;
 	unsigned long long v;
-	
+
 	memmove(sig0, signature, 32);
 	memmove(sig1, signature, 32);
 	memmove(sig2, signature, 32);
@@ -1283,7 +1284,7 @@ void procscoop_m256_8(unsigned long long const nonce, unsigned long long const n
 		mshabal256(&x, (const unsigned char*)sig0, (const unsigned char*)sig1, (const unsigned char*)sig2, (const unsigned char*)sig3, (const unsigned char*)sig4, (const unsigned char*)sig5, (const unsigned char*)sig6, (const unsigned char*)sig7, 64 + 32);
 		mshabal256_close(&x, 0, 0, 0, 0, 0, 0, 0, 0, 0, res0, res1, res2, res3, res4, res5, res6, res7);
 
-		unsigned long long *wertung  = (unsigned long long*)res0;
+		unsigned long long *wertung = (unsigned long long*)res0;
 		unsigned long long *wertung1 = (unsigned long long*)res1;
 		unsigned long long *wertung2 = (unsigned long long*)res2;
 		unsigned long long *wertung3 = (unsigned long long*)res3;
@@ -1327,29 +1328,29 @@ void procscoop_m256_8(unsigned long long const nonce, unsigned long long const n
 			*wertung = *wertung7;
 			posn = 7;
 		}
-		
+
 		if ((*wertung / baseTarget) <= bests[acc].targetDeadline)
 		{
-				if (bests[acc].nonce == 0 || *wertung < bests[acc].best)
+			if (bests[acc].nonce == 0 || *wertung < bests[acc].best)
+			{
+				Log("\nfound deadline=");	Log_llu(*wertung / baseTarget); Log(" nonce=");	Log_llu(nonce + v + posn); Log(" for account: "); Log_llu(bests[acc].account_id); Log(" file: "); Log((char*)file_name.c_str());
+				EnterCriticalSection(&bestsLock);
+				bests[acc].best = *wertung;
+				bests[acc].nonce = nonce + v + posn;
+				bests[acc].DL = *wertung / baseTarget;
+				LeaveCriticalSection(&bestsLock);
+				EnterCriticalSection(&sharesLock);
+				shares.push_back({ file_name, bests[acc].account_id, bests[acc].best, bests[acc].nonce });
+				LeaveCriticalSection(&sharesLock);
+				if (use_debug)
 				{
-					Log("\nfound deadline=");	Log_llu(*wertung / baseTarget); Log(" nonce=");	Log_llu(nonce + v + posn); Log(" for account: "); Log_llu(bests[acc].account_id); Log(" file: "); Log((char*)file_name.c_str());
-					EnterCriticalSection(&bestsLock);
-					bests[acc].best = *wertung;
-					bests[acc].nonce = nonce + v + posn;
-					bests[acc].DL = *wertung / baseTarget;
-					LeaveCriticalSection(&bestsLock);
-					EnterCriticalSection(&sharesLock);
-					shares.push_back({ file_name, bests[acc].account_id, bests[acc].best, bests[acc].nonce });
-					LeaveCriticalSection(&sharesLock);
-					if (use_debug)
-					{
-						char tbuffer[9];
-						_strtime_s(tbuffer);
-						wattron(win_main, COLOR_PAIR(2));
-						wprintw(win_main, "%s [%20llu] found DL:      %9llu\n", tbuffer, bests[acc].account_id, bests[acc].DL, 0);
-						wattroff(win_main, COLOR_PAIR(2));
-					}
+					char tbuffer[9];
+					_strtime_s(tbuffer);
+					wattron(win_main, COLOR_PAIR(2));
+					wprintw(win_main, "%s [%20llu] found DL:      %9llu\n", tbuffer, bests[acc].account_id, bests[acc].DL, 0);
+					wattroff(win_main, COLOR_PAIR(2));
 				}
+			}
 		}
 	}
 }
@@ -1360,13 +1361,13 @@ void procscoop_sph(const unsigned long long nonce, const unsigned long long n, c
 	cache = data;
 	char res[32];
 	memcpy_s(sig, sizeof(sig), signature, sizeof(char) * 32);
-	
+
 	sph_shabal_context x, init_x;
 	sph_shabal256_init(&init_x);
 	for (unsigned long long v = 0; v < n; v++)
 	{
-		memcpy_s(&sig[32], sizeof(sig)-32, &cache[v * 64], sizeof(char)* 64);
-		
+		memcpy_s(&sig[32], sizeof(sig) - 32, &cache[v * 64], sizeof(char) * 64);
+
 		memcpy(&x, &init_x, sizeof(init_x)); // optimization: sph_shabal256_init(&x);
 		sph_shabal256(&x, (const unsigned char*)sig, 64 + 32);
 		sph_shabal256_close(&x, res);
@@ -1375,26 +1376,26 @@ void procscoop_sph(const unsigned long long nonce, const unsigned long long n, c
 
 		if ((*wertung / baseTarget) <= bests[acc].targetDeadline)
 		{
-				if (bests[acc].nonce == 0 || *wertung < bests[acc].best)
+			if (bests[acc].nonce == 0 || *wertung < bests[acc].best)
+			{
+				Log("\nfound deadline=");	Log_llu(*wertung / baseTarget); Log(" nonce=");	Log_llu(nonce + v); Log(" for account: "); Log_llu(bests[acc].account_id); Log(" file: "); Log((char*)file_name.c_str());
+				EnterCriticalSection(&bestsLock);
+				bests[acc].best = *wertung;
+				bests[acc].nonce = nonce + v;
+				bests[acc].DL = *wertung / baseTarget;
+				LeaveCriticalSection(&bestsLock);
+				EnterCriticalSection(&sharesLock);
+				shares.push_back({ file_name, bests[acc].account_id, bests[acc].best, bests[acc].nonce });
+				LeaveCriticalSection(&sharesLock);
+				if (use_debug)
 				{
-					Log("\nfound deadline=");	Log_llu(*wertung / baseTarget); Log(" nonce=");	Log_llu(nonce + v); Log(" for account: "); Log_llu(bests[acc].account_id); Log(" file: "); Log((char*)file_name.c_str());
-					EnterCriticalSection(&bestsLock);
-					bests[acc].best = *wertung;
-					bests[acc].nonce = nonce + v;
-					bests[acc].DL = *wertung / baseTarget;
-					LeaveCriticalSection(&bestsLock);
-					EnterCriticalSection(&sharesLock);
-					shares.push_back({ file_name, bests[acc].account_id, bests[acc].best, bests[acc].nonce });
-					LeaveCriticalSection(&sharesLock);
-					if (use_debug)
-					{
-						char tbuffer[9];
-						_strtime_s(tbuffer);
-						wattron(win_main, COLOR_PAIR(2));
-						wprintw(win_main, "%s [%20llu] found DL:      %9llu\n", tbuffer, bests[acc].account_id, bests[acc].DL, 0);
-						wattroff(win_main, COLOR_PAIR(2));
-					}
+					char tbuffer[9];
+					_strtime_s(tbuffer);
+					wattron(win_main, COLOR_PAIR(2));
+					wprintw(win_main, "%s [%20llu] found DL:      %9llu\n", tbuffer, bests[acc].account_id, bests[acc].DL, 0);
+					wattroff(win_main, COLOR_PAIR(2));
 				}
+			}
 		}
 	}
 }
@@ -1418,32 +1419,32 @@ void procscoop_asm(const unsigned long long nonce, const unsigned long long n, c
 
 		if ((*wertung / baseTarget) <= bests[acc].targetDeadline)
 		{
-				if (bests[acc].nonce == 0 || *wertung < bests[acc].best)
+			if (bests[acc].nonce == 0 || *wertung < bests[acc].best)
+			{
+				Log("\nfound deadline=");	Log_llu(*wertung / baseTarget); Log(" nonce=");	Log_llu(nonce + v); Log(" for account: "); Log_llu(bests[acc].account_id); Log(" file: "); Log((char*)file_name.c_str());
+				EnterCriticalSection(&bestsLock);
+				bests[acc].best = *wertung;
+				bests[acc].nonce = nonce + v;
+				bests[acc].DL = *wertung / baseTarget;
+				LeaveCriticalSection(&bestsLock);
+				EnterCriticalSection(&sharesLock);
+				shares.push_back({ file_name, bests[acc].account_id, bests[acc].best, bests[acc].nonce });
+				LeaveCriticalSection(&sharesLock);
+				if (use_debug)
 				{
-					Log("\nfound deadline=");	Log_llu(*wertung / baseTarget); Log(" nonce=");	Log_llu(nonce + v); Log(" for account: "); Log_llu(bests[acc].account_id); Log(" file: "); Log((char*)file_name.c_str());
-					EnterCriticalSection(&bestsLock);
-					bests[acc].best = *wertung;
-					bests[acc].nonce = nonce + v;
-					bests[acc].DL = *wertung / baseTarget;
-					LeaveCriticalSection(&bestsLock);
-					EnterCriticalSection(&sharesLock);
-					shares.push_back({ file_name, bests[acc].account_id, bests[acc].best, bests[acc].nonce });
-					LeaveCriticalSection(&sharesLock);
-					if (use_debug)
-					{
-						char tbuffer[9];
-						_strtime_s(tbuffer);
-						wattron(win_main, COLOR_PAIR(2));
-						wprintw(win_main, "%s [%20llu] found DL:      %9llu\n", tbuffer, bests[acc].account_id, bests[acc].DL, 0);
-						wattroff(win_main, COLOR_PAIR(2));
-					}
+					char tbuffer[9];
+					_strtime_s(tbuffer);
+					wattron(win_main, COLOR_PAIR(2));
+					wprintw(win_main, "%s [%20llu] found DL:      %9llu\n", tbuffer, bests[acc].account_id, bests[acc].DL, 0);
+					wattroff(win_main, COLOR_PAIR(2));
 				}
+			}
 		}
 	}
 }
 
 void work_i(const size_t local_num) {
-	
+
 	__int64 start_work_time, end_work_time;
 	__int64 start_time_read, end_time_read;
 	__int64 start_time_proc;
@@ -1452,22 +1453,22 @@ void work_i(const size_t local_num) {
 	QueryPerformanceFrequency(&li);
 	double const pcFreq = double(li.QuadPart);
 	QueryPerformanceCounter((LARGE_INTEGER*)&start_work_time);
-		
+
 	if (use_boost)
 	{
 		//SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
 		//SetThreadAffinityMask(GetCurrentThread(), 1 << (int)(working_threads));
-		SetThreadIdealProcessor(GetCurrentThread(), (DWORD)(local_num % std::thread::hardware_concurrency()) );
+		SetThreadIdealProcessor(GetCurrentThread(), (DWORD)(local_num % std::thread::hardware_concurrency()));
 	}
-	
+
 	std::string const path_loc_str = paths_dir[local_num];
 	unsigned long long files_size_per_thread = 0;
-		
+
 	Log("\nStart thread: ["); Log_llu(local_num); Log("]  ");	Log((char*)path_loc_str.c_str());
 
 	std::vector<t_files> files;
 	GetFiles(path_loc_str, &files);
-	
+
 	size_t cache_size_local;
 	DWORD sectorsPerCluster;
 	DWORD bytesPerSector;
@@ -1494,7 +1495,7 @@ void work_i(const size_t local_num) {
 		}
 
 		// Проверка на повреждения плота
-		if (nonces != (iter->Size) / (4096 * 64)) 
+		if (nonces != (iter->Size) / (4096 * 64))
 		{
 			wattron(win_main, COLOR_PAIR(12));
 			wprintw(win_main, "file \"%s\" name/size mismatch\n", iter->Name.c_str(), 0);
@@ -1502,13 +1503,13 @@ void work_i(const size_t local_num) {
 			if (nonces != stagger)
 				nonces = (((iter->Size) / (4096 * 64)) / stagger) * stagger; //обрезаем плот по размеру и стаггеру
 			else
-			if (scoop > (iter->Size) / (stagger * 64)) //если номер скупа попадает в поврежденный смерженный плот, то пропускаем
-			{
-				wattron(win_main, COLOR_PAIR(12));
-				wprintw(win_main, "skipped\n", 0);
-				wattroff(win_main, COLOR_PAIR(12));
-				continue;
-			}
+				if (scoop > (iter->Size) / (stagger * 64)) //если номер скупа попадает в поврежденный смерженный плот, то пропускаем
+				{
+					wattron(win_main, COLOR_PAIR(12));
+					wprintw(win_main, "skipped\n", 0);
+					wattroff(win_main, COLOR_PAIR(12));
+					continue;
+				}
 		}
 
 		if (!GetDiskFreeSpaceA((iter->Path).c_str(), &sectorsPerCluster, &bytesPerSector, &numberOfFreeClusters, &totalNumberOfClusters))
@@ -1523,7 +1524,7 @@ void work_i(const size_t local_num) {
 		if ((stagger * 64) < bytesPerSector)
 		{
 			wattron(win_main, COLOR_PAIR(12));
-			wprintw(win_main, "stagger (%llu) must be >= %llu\n", stagger, bytesPerSector/64, 0);
+			wprintw(win_main, "stagger (%llu) must be >= %llu\n", stagger, bytesPerSector / 64, 0);
 			wattroff(win_main, COLOR_PAIR(12));
 			continue;
 		}
@@ -1532,13 +1533,13 @@ void work_i(const size_t local_num) {
 		if ((nonces * 64) < bytesPerSector)
 		{
 			wattron(win_main, COLOR_PAIR(12));
-			wprintw(win_main, "nonces (%llu) must be >= %llu\n", nonces, bytesPerSector/64, 0);
+			wprintw(win_main, "nonces (%llu) must be >= %llu\n", nonces, bytesPerSector / 64, 0);
 			wattroff(win_main, COLOR_PAIR(12));
 			continue;
 		}
 
 		// Если стаггер не выровнен по сектору - можем читать сдвигая последний стагер назад (доделать)
-		if ((stagger % (bytesPerSector/64)) != 0)
+		if ((stagger % (bytesPerSector / 64)) != 0)
 		{
 			wattron(win_main, COLOR_PAIR(12));
 			wprintw(win_main, "stagger (%llu) must be a multiple of %llu\n", stagger, bytesPerSector / 64, 0);
@@ -1557,7 +1558,8 @@ void work_i(const size_t local_num) {
 		if (p2 != POC2) {
 			if ((stagger == nonces) && (cache_size2 < stagger)) cache_size_local = cache_size2;  // оптимизированный плот
 			else cache_size_local = stagger; // обычный плот
-		}else{
+		}
+		else {
 			if ((stagger == nonces) && (cache_size < stagger)) cache_size_local = cache_size;  // оптимизированный плот
 			else cache_size_local = stagger; // обычный плот
 		}
@@ -1574,7 +1576,7 @@ void work_i(const size_t local_num) {
 		if (MirrorCache == nullptr) ShowMemErrorExit();
 
 		Log("\nRead file : ");	Log((char*)iter->Name.c_str());
-		
+
 		//wprintw(win_main, "%S \n", str2wstr(iter->Path + iter->Name).c_str());
 		HANDLE ifile = CreateFileA((iter->Path + iter->Name).c_str(), GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_FLAG_NO_BUFFERING, nullptr);
 		if (ifile == INVALID_HANDLE_VALUE)
@@ -1587,15 +1589,16 @@ void work_i(const size_t local_num) {
 			continue;
 		}
 		files_size_per_thread += iter->Size;
-		
+
 		unsigned long long start, bytes;
 		DWORD b = 0;
 		LARGE_INTEGER liDistanceToMove;
-		
+
 		//PoC2 Vars
 		unsigned long long MirrorStart;
 		DWORD Mirrorb = 0;
 		LARGE_INTEGER MirrorliDistanceToMove;
+		bool flip = false;
 
 		size_t acc = Get_index_acc(key);
 		for (unsigned long long n = 0; n < nonces; n += stagger)
@@ -1607,78 +1610,83 @@ void work_i(const size_t local_num) {
 				if (i + cache_size_local > stagger)
 				{
 					cache_size_local = stagger - i;  // остаток
-					#ifdef __AVX2__
+#ifdef __AVX2__
 					if (cache_size_local < 8)
 					{
 						wattron(win_main, COLOR_PAIR(12));
 						wprintw(win_main, "WARNING: %llu\n", cache_size_local);
 						wattroff(win_main, COLOR_PAIR(12));
 					}
-					#else
-						#ifdef __AVX__
-						if (cache_size_local < 4)
-						{
+#else
+#ifdef __AVX__
+					if (cache_size_local < 4)
+					{
 						wattron(win_main, COLOR_PAIR(12));
 						wprintw(win_main, "WARNING: %llu\n", cache_size_local);
 						wattroff(win_main, COLOR_PAIR(12));
-						}
-						#endif
-					#endif
-				}
-				bytes = 0;
-				b = 0;
-				liDistanceToMove.QuadPart = start + i*64;
-				if (!SetFilePointerEx(ifile, liDistanceToMove, nullptr, FILE_BEGIN))
-				{
-					wprintw(win_main, "error SetFilePointerEx. code = %llu\n", GetLastError(), 0);
-					continue;
-				}
-
-				do {
-					if (!ReadFile(ifile, &cache[bytes], (DWORD)(cache_size_local * 64), &b, NULL))
-					{
-						wattron(win_main, COLOR_PAIR(12));
-						wprintw(win_main, ("error ReadFile. code =" + iter->Path + iter->Name + "\n").c_str(), 0);
-						wattroff(win_main, COLOR_PAIR(12));
-						break;
 					}
-					bytes += b;
-					//wprintw(win_main, "%llu   %llu\n", bytes, readsize);
-				} while (bytes < cache_size_local * 64);
+#endif
+#endif
+				}
 
-				//Shuffle if file POC not matching network POC
+				//Shuffle message if file POC not matching network POC
 				if (p2 != POC2 && i == 0) {
 					wattron(win_main, COLOR_PAIR(11));
 					wprintw(win_main, ("POC shuffling active for: " + iter->Path + iter->Name + "\n").c_str(), 0);
 					wattroff(win_main, COLOR_PAIR(11));
 				}
 
+				if (flip) goto poc2read;
+				//POC1 scoop read
+			poc1read:
+				bytes = 0;
+				b = 0;
+				liDistanceToMove.QuadPart = start + i * 64;
+				if (!SetFilePointerEx(ifile, liDistanceToMove, nullptr, FILE_BEGIN))
+				{
+					wprintw(win_main, "error SetFilePointerEx. code = %llu\n", GetLastError(), 0);
+					continue;
+				}
+				do {
+					if (!ReadFile(ifile, &cache[bytes], (DWORD)(cache_size_local * 64), &b, NULL))
+					{
+						wattron(win_main, COLOR_PAIR(12));
+						wprintw(win_main, ("error P1 ReadFile. code =" + iter->Path + iter->Name + "\n").c_str(), 0);
+						wattroff(win_main, COLOR_PAIR(12));
+						break;
+					}
+					bytes += b;
+				} while (bytes < cache_size_local * 64);
+				if (flip) goto readend;
+
+			poc2read:
+				//PoC2 mirror scoop read
 				if (p2 != POC2) {
-					//PoC2 Read Mirror Scoop
 					bytes = 0;
 					Mirrorb = 0;
 					MirrorliDistanceToMove.QuadPart = MirrorStart + i * 64;
-
 					if (!SetFilePointerEx(ifile, MirrorliDistanceToMove, nullptr, FILE_BEGIN))
 					{
 						wprintw(win_main, "error SetFilePointerEx. code = %llu\n", GetLastError(), 0);
 						continue;
 					}
-
 					do {
 						if (!ReadFile(ifile, &MirrorCache[bytes], (DWORD)(cache_size_local * 64), &Mirrorb, NULL))
 						{
 							wattron(win_main, COLOR_PAIR(12));
-							wprintw(win_main, "error ReadFile. code = %llu\n", GetLastError(), 0);
+							wprintw(win_main, "error P2 ReadFile. code = %llu\n", GetLastError(), 0);
 							wattroff(win_main, COLOR_PAIR(12));
 							break;
 						}
 						bytes += Mirrorb;
-
 					} while (bytes < cache_size_local * 64);
+				}
+				if (flip) goto poc1read;
+			readend:
+				flip = !flip;
 
-					//PoC2
-					//Merge data to Cache
+				//PoC2 Merge data to Cache
+				if (p2 != POC2) {
 					for (unsigned long t = 0; t < bytes; t += 64) {
 						memcpy(&cache[t + 32], &MirrorCache[t + 32], 32); //copy second hash to correct place.
 					}
@@ -1687,19 +1695,19 @@ void work_i(const size_t local_num) {
 				if (bytes == cache_size_local * 64)
 				{
 					QueryPerformanceCounter((LARGE_INTEGER*)&start_time_proc);
-					#ifdef __AVX2__
-						procscoop_m256_8(n + nonce + i, cache_size_local, cache, acc, iter->Name);// Process block AVX2
-					#else
-						#ifdef __AVX__
-							procscoop_m_4(n + nonce + i, cache_size_local, cache, acc, iter->Name);// Process block AVX
-						#else
-							procscoop_sph(n + nonce + i, cache_size_local, cache, acc, iter->Name);// Process block SSE4
-						#endif
-					#endif
+#ifdef __AVX2__
+					procscoop_m256_8(n + nonce + i, cache_size_local, cache, acc, iter->Name);// Process block AVX2
+#else
+#ifdef __AVX__
+					procscoop_m_4(n + nonce + i, cache_size_local, cache, acc, iter->Name);// Process block AVX
+#else
+					procscoop_sph(n + nonce + i, cache_size_local, cache, acc, iter->Name);// Process block SSE4
+#endif
+#endif
 					QueryPerformanceCounter(&li);
 					sum_time_proc += (double)(li.QuadPart - start_time_proc);
 					worker_progress[local_num].Reads_bytes += bytes;
-					
+
 				}
 				else
 				{
@@ -1718,7 +1726,7 @@ void work_i(const size_t local_num) {
 					VirtualFree(cache, 0, MEM_RELEASE);
 					VirtualFree(MirrorCache, 0, MEM_RELEASE); //PoC2 Cleanup
 
-					//if (use_boost) SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
+															  //if (use_boost) SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
 					return;
 				}
 			}
@@ -1731,7 +1739,7 @@ void work_i(const size_t local_num) {
 	}
 	worker_progress[local_num].isAlive = false;
 	QueryPerformanceCounter((LARGE_INTEGER*)&end_work_time);
-	
+
 	//if (use_boost) SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
 
 	double thread_time = (double)(end_work_time - start_work_time) / pcFreq;
@@ -1762,7 +1770,7 @@ char* GetJSON(char const *const req) {
 	char *json = nullptr;
 
 	RtlSecureZeroMemory(&hints, sizeof(hints));
-	hints.ai_family = AF_INET; 
+	hints.ai_family = AF_INET;
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
 
@@ -2060,11 +2068,11 @@ void pollLocal(void) {
 					if (network_quality > 0) network_quality--;
 					Log("\n*! GMI: send request failed: "); Log_u(WSAGetLastError());
 				}
-				else{
+				else {
 					RtlSecureZeroMemory(buffer, buffer_size);
 					size_t  pos = 0;
 					iResult = 0;
-					do{
+					do {
 						iResult = recv(UpdaterSocket, &buffer[pos], (int)(buffer_size - pos - 1), 0);
 						if (iResult > 0) pos += (size_t)iResult;
 					} while (iResult > 0);
@@ -2076,7 +2084,7 @@ void pollLocal(void) {
 					else {
 						if (network_quality < 100) network_quality++;
 						Log("\n* GMI: Received: "); Log_server(buffer);
-						
+
 						// locate HTTP header
 						char *find = strstr(buffer, "\r\n\r\n");
 						if (find == nullptr)	Log("\n*! GMI: error message from pool");
@@ -2151,67 +2159,67 @@ void pollLocal2(void) {
 		Log(updateraddr.c_str());
 	}
 	else {
-			setsockopt(UpdaterSocket, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, NULL, 0);
+		setsockopt(UpdaterSocket, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, NULL, 0);
 
-			int bytes = sprintf_s(buffer, buffer_size, "POST /burst?requestType=getMiningInfo HTTP/1.0\r\nHost: %s:%s\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", nodeaddr.c_str(), nodeport.c_str());
-				iResult = send(UpdaterSocket, buffer, bytes, 0);
-				if (iResult == SOCKET_ERROR)
-				{
-					if (network_quality > 0) network_quality--;
-					Log("\n*! GMI: send request failed: "); Log_u(WSAGetLastError());
-				}
-				else{
-					RtlSecureZeroMemory(buffer, buffer_size);
-					size_t  pos = 0;
-					iResult = 0;
-					do{
-						iResult = recv(UpdaterSocket, &buffer[pos], (int)(buffer_size - pos - 1), 0);
-						if (iResult > 0) pos += (size_t)iResult;
-					} while (iResult > 0);
-					if (iResult == SOCKET_ERROR)
-					{
-						if (network_quality > 0) network_quality--;
-						Log("\n*! GMI: get mining info failed:: "); Log_u(WSAGetLastError());
-					}
+		int bytes = sprintf_s(buffer, buffer_size, "POST /burst?requestType=getMiningInfo HTTP/1.0\r\nHost: %s:%s\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", nodeaddr.c_str(), nodeport.c_str());
+		iResult = send(UpdaterSocket, buffer, bytes, 0);
+		if (iResult == SOCKET_ERROR)
+		{
+			if (network_quality > 0) network_quality--;
+			Log("\n*! GMI: send request failed: "); Log_u(WSAGetLastError());
+		}
+		else {
+			RtlSecureZeroMemory(buffer, buffer_size);
+			size_t  pos = 0;
+			iResult = 0;
+			do {
+				iResult = recv(UpdaterSocket, &buffer[pos], (int)(buffer_size - pos - 1), 0);
+				if (iResult > 0) pos += (size_t)iResult;
+			} while (iResult > 0);
+			if (iResult == SOCKET_ERROR)
+			{
+				if (network_quality > 0) network_quality--;
+				Log("\n*! GMI: get mining info failed:: "); Log_u(WSAGetLastError());
+			}
+			else {
+				if (network_quality < 100) network_quality++;
+				Log("\n* GMI: Received: "); Log_server(buffer);
+
+				// locate HTTP header
+				char *find = strstr(buffer, "\r\n\r\n");
+				if (find == nullptr)	Log("\n*! GMI: error message from pool");
+				else {
+					rapidjson::Document gmi;
+					if (gmi.Parse<0>(find).HasParseError()) Log("\n*! GMI: error parsing JSON message from pool");
 					else {
-						if (network_quality < 100) network_quality++;
-						Log("\n* GMI: Received: "); Log_server(buffer);
+						if (gmi.IsObject())
+						{
+							if (gmi.HasMember("baseTarget")) {
+								if (gmi["baseTarget"].IsString())	baseTarget = _strtoui64(gmi["baseTarget"].GetString(), 0, 10);
+								else
+									if (gmi["baseTarget"].IsInt64()) baseTarget = gmi["baseTarget"].GetInt64();
+							}
 
-						// locate HTTP header
-						char *find = strstr(buffer, "\r\n\r\n");
-						if (find == nullptr)	Log("\n*! GMI: error message from pool");
-						else {
-							rapidjson::Document gmi;
-							if (gmi.Parse<0>(find).HasParseError()) Log("\n*! GMI: error parsing JSON message from pool");
-							else {
-								if (gmi.IsObject())
-								{
-									if (gmi.HasMember("baseTarget")) {
-										if (gmi["baseTarget"].IsString())	baseTarget = _strtoui64(gmi["baseTarget"].GetString(), 0, 10);
-										else
-											if (gmi["baseTarget"].IsInt64()) baseTarget = gmi["baseTarget"].GetInt64();
-									}
+							if (gmi.HasMember("height")) {
+								if (gmi["height"].IsString())	height = _strtoui64(gmi["height"].GetString(), 0, 10);
+								else
+									if (gmi["height"].IsInt64()) height = gmi["height"].GetInt64();
+							}
 
-									if (gmi.HasMember("height")) {
-										if (gmi["height"].IsString())	height = _strtoui64(gmi["height"].GetString(), 0, 10);
-										else
-											if (gmi["height"].IsInt64()) height = gmi["height"].GetInt64();
-									}
-
-									if (gmi.HasMember("generationSignature")) {
-										strcpy_s(str_signature, gmi["generationSignature"].GetString());
-										if (xstr2strr(signature, 33, gmi["generationSignature"].GetString()) == 0)	Log("\n*! GMI: Node response: Error decoding generationsignature\n");
-									}
-									if (gmi.HasMember("targetDeadline")) {
-										if (gmi["targetDeadline"].IsString())	targetDeadlineInfo = _strtoui64(gmi["targetDeadline"].GetString(), 0, 10);
-										else
-											if (gmi["targetDeadline"].IsInt64()) targetDeadlineInfo = gmi["targetDeadline"].GetInt64();
-									}
-								}
+							if (gmi.HasMember("generationSignature")) {
+								strcpy_s(str_signature, gmi["generationSignature"].GetString());
+								if (xstr2strr(signature, 33, gmi["generationSignature"].GetString()) == 0)	Log("\n*! GMI: Node response: Error decoding generationsignature\n");
+							}
+							if (gmi.HasMember("targetDeadline")) {
+								if (gmi["targetDeadline"].IsString())	targetDeadlineInfo = _strtoui64(gmi["targetDeadline"].GetString(), 0, 10);
+								else
+									if (gmi["targetDeadline"].IsInt64()) targetDeadlineInfo = gmi["targetDeadline"].GetInt64();
 							}
 						}
 					}
 				}
+			}
+		}
 	}
 	closesocket(UpdaterSocket);
 	HeapFree(hHeap, 0, buffer);
@@ -2224,7 +2232,7 @@ void updater_i(void) {
 		Log("\nGMI: ERROR in UpdaterAddr");
 		exit(2);
 	}
-	for (; !exit_flag;)	{
+	for (; !exit_flag;) {
 		pollLocal();
 		std::this_thread::yield();
 		std::this_thread::sleep_for(std::chrono::milliseconds(update_interval));
@@ -2252,7 +2260,7 @@ void hostname_to_ip(char const *const  in_addr, char* out_addr)
 	}
 	for (ptr = result; ptr != nullptr; ptr = ptr->ai_next) {
 
-		if(ptr->ai_family == AF_INET)
+		if (ptr->ai_family == AF_INET)
 		{
 			sockaddr_ipv4 = (struct sockaddr_in *) ptr->ai_addr;
 			char str[INET_ADDRSTRLEN];
@@ -2267,47 +2275,47 @@ void hostname_to_ip(char const *const  in_addr, char* out_addr)
 
 void GetCPUInfo(void)
 {
-		ULONGLONG  TotalMemoryInKilobytes = 0;
-		
-		wprintw(win_main, "CPU support: ");
-		if (InstructionSet::AES())    wprintw(win_main, " AES ", 0);
-		if (InstructionSet::SSE())   wprintw(win_main, " SSE ", 0);
-		if (InstructionSet::SSE2())   wprintw(win_main, " SSE2 ", 0);
-		if (InstructionSet::SSE3())   wprintw(win_main, " SSE3 ", 0);
-		if (InstructionSet::SSE42())   wprintw(win_main, " SSE4.2 ", 0);
-		if (InstructionSet::AVX())   wprintw(win_main, " AVX ", 0);
-		if (InstructionSet::AVX2())  	wprintw(win_main, " AVX2 ", 0);
-		
+	ULONGLONG  TotalMemoryInKilobytes = 0;
+
+	wprintw(win_main, "CPU support: ");
+	if (InstructionSet::AES())    wprintw(win_main, " AES ", 0);
+	if (InstructionSet::SSE())   wprintw(win_main, " SSE ", 0);
+	if (InstructionSet::SSE2())   wprintw(win_main, " SSE2 ", 0);
+	if (InstructionSet::SSE3())   wprintw(win_main, " SSE3 ", 0);
+	if (InstructionSet::SSE42())   wprintw(win_main, " SSE4.2 ", 0);
+	if (InstructionSet::AVX())   wprintw(win_main, " AVX ", 0);
+	if (InstructionSet::AVX2())  	wprintw(win_main, " AVX2 ", 0);
+
 #ifndef __AVX__
-		// Checking for AVX requires 3 things:
-		// 1) CPUID indicates that the OS uses XSAVE and XRSTORE instructions (allowing saving YMM registers on context switch)
-		// 2) CPUID indicates support for AVX
-		// 3) XGETBV indicates the AVX registers will be saved and restored on context switch
-		bool avxSupported = false;
-		int cpuInfo[4];
-		__cpuid(cpuInfo, 1);
+	// Checking for AVX requires 3 things:
+	// 1) CPUID indicates that the OS uses XSAVE and XRSTORE instructions (allowing saving YMM registers on context switch)
+	// 2) CPUID indicates support for AVX
+	// 3) XGETBV indicates the AVX registers will be saved and restored on context switch
+	bool avxSupported = false;
+	int cpuInfo[4];
+	__cpuid(cpuInfo, 1);
 
-		bool osUsesXSAVE_XRSTORE = cpuInfo[2] & (1 << 27) || false;
-		bool cpuAVXSuport = cpuInfo[2] & (1 << 28) || false;
+	bool osUsesXSAVE_XRSTORE = cpuInfo[2] & (1 << 27) || false;
+	bool cpuAVXSuport = cpuInfo[2] & (1 << 28) || false;
 
-		if (osUsesXSAVE_XRSTORE && cpuAVXSuport)
-		{
-			// Check if the OS will save the YMM registers
-			unsigned long long xcrFeatureMask = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
-			avxSupported = (xcrFeatureMask & 0x6) == 0x6;
-		}
-		if (avxSupported)	wprintw(win_main, "     [recomend use AVX]", 0);
+	if (osUsesXSAVE_XRSTORE && cpuAVXSuport)
+	{
+		// Check if the OS will save the YMM registers
+		unsigned long long xcrFeatureMask = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+		avxSupported = (xcrFeatureMask & 0x6) == 0x6;
+	}
+	if (avxSupported)	wprintw(win_main, "     [recomend use AVX]", 0);
 #endif
-		if (InstructionSet::AVX2()) wprintw(win_main, "     [recomend use AVX2]", 0);
-		SYSTEM_INFO sysinfo;
-		GetSystemInfo(&sysinfo);
-		wprintw(win_main, "\n%s", InstructionSet::Vendor().c_str(), 0);
-		wprintw(win_main, " %s  [%u cores]", InstructionSet::Brand().c_str(), sysinfo.dwNumberOfProcessors);
+	if (InstructionSet::AVX2()) wprintw(win_main, "     [recomend use AVX2]", 0);
+	SYSTEM_INFO sysinfo;
+	GetSystemInfo(&sysinfo);
+	wprintw(win_main, "\n%s", InstructionSet::Vendor().c_str(), 0);
+	wprintw(win_main, " %s  [%u cores]", InstructionSet::Brand().c_str(), sysinfo.dwNumberOfProcessors);
 
-		if (GetPhysicallyInstalledSystemMemory(&TotalMemoryInKilobytes))
-			wprintw(win_main, "\nRAM: %llu Mb", (unsigned long long)TotalMemoryInKilobytes / 1024, 0);
-		
-		wprintw(win_main, "\n", 0);
+	if (GetPhysicallyInstalledSystemMemory(&TotalMemoryInKilobytes))
+		wprintw(win_main, "\nRAM: %llu Mb", (unsigned long long)TotalMemoryInKilobytes / 1024, 0);
+
+	wprintw(win_main, "\n", 0);
 }
 
 
@@ -2315,80 +2323,80 @@ void GetCPUInfo(void)
 #ifdef GPU_ON_CPP
 std::vector<std::shared_ptr<OpenclPlatform>> GPU_PlatformInfo(void)
 {
-	//инициализация платформы
+//инициализация платформы
 
-	try {
-		std::vector<std::shared_ptr<OpenclPlatform>> platforms(OpenclPlatform::list());
-		printf("\nPlatforms number: %u\n", platforms.size());
+try {
+std::vector<std::shared_ptr<OpenclPlatform>> platforms(OpenclPlatform::list());
+printf("\nPlatforms number: %u\n", platforms.size());
 
-		std::size_t i = 0;
-		for (const std::shared_ptr<OpenclPlatform>& platform : platforms) {
-			printf("\n----");
-			printf("\nId:       %u", i++);
-			printf("\nName:     %s", (platform->getName()).c_str());
-			printf("\nVendor:   %s", (platform->getVendor()).c_str());
-			printf("\nVersion:  %s\n", (platform->getVersion()).c_str());
-		}
-		return platforms;
-	}
-	catch (const OpenclError& ex) {
-		printf("\n[ERROR][%u][%s] %s", ex.getCode(), ex.getCodeString().c_str(), ex.what());
-		//return -1;
-	}
-	catch (const std::exception& ex) {
-		printf("\n[ERROR] %s", ex.what());
-		//return -1;
-	}
+std::size_t i = 0;
+for (const std::shared_ptr<OpenclPlatform>& platform : platforms) {
+printf("\n----");
+printf("\nId:       %u", i++);
+printf("\nName:     %s", (platform->getName()).c_str());
+printf("\nVendor:   %s", (platform->getVendor()).c_str());
+printf("\nVersion:  %s\n", (platform->getVersion()).c_str());
+}
+return platforms;
+}
+catch (const OpenclError& ex) {
+printf("\n[ERROR][%u][%s] %s", ex.getCode(), ex.getCodeString().c_str(), ex.what());
+//return -1;
+}
+catch (const std::exception& ex) {
+printf("\n[ERROR] %s", ex.what());
+//return -1;
+}
 }
 
 int GPU_DeviceInfo(unsigned platform)
 {
-	//инициализация девайсов
-	try {
-		std::size_t platformId = platform; //std::atol(p_args[0].c_str());
+//инициализация девайсов
+try {
+std::size_t platformId = platform; //std::atol(p_args[0].c_str());
 
-		std::vector<std::shared_ptr<OpenclPlatform>> platforms(OpenclPlatform::list());
-		if (platformId >= platforms.size()) {
-			throw std::runtime_error("No platform found with the provided id");
-		}
+std::vector<std::shared_ptr<OpenclPlatform>> platforms(OpenclPlatform::list());
+if (platformId >= platforms.size()) {
+throw std::runtime_error("No platform found with the provided id");
+}
 
-		//std::vector<unsigned long long> sizeUnits{ 1024, 1024, 1024 };
-		//std::vector<std::string> sizeLabels{ "KB", "MB", "GB", "TB" };
+//std::vector<unsigned long long> sizeUnits{ 1024, 1024, 1024 };
+//std::vector<std::string> sizeLabels{ "KB", "MB", "GB", "TB" };
 
-		std::vector<std::shared_ptr<OpenclDevice>> devices(OpenclDevice::list(platforms[platformId]));
-		printf("\nDevices number : %u", devices.size());
+std::vector<std::shared_ptr<OpenclDevice>> devices(OpenclDevice::list(platforms[platformId]));
+printf("\nDevices number : %u", devices.size());
 
-		std::size_t i = 0;
-		for (const std::shared_ptr<OpenclDevice>& device : devices) {
-			printf("\n----");
-			printf("\nId:                          %u", i++);
-			printf("\nType:                        %s", device->getType().c_str());
-			printf("\nName:                        %s", device->getName().c_str());
-			printf("\nVendor:                      %s", device->getVendor().c_str());
-			printf("\nVersion:                     %s", device->getVersion().c_str());
-			printf("\nDriver version:              %s", device->getDriverVersion().c_str());
-			printf("\nMax clock frequency:         %u Mhz", device->getMaxClockFrequency());
-			printf("\nMax compute units:           %u", device->getMaxComputeUnits());
-			printf("\nGlobal memory size:          %llu Mb", device->getGlobalMemorySize()>>20); //cryo::util::formatValue(device->getGlobalMemorySize() >> 10, sizeUnits, sizeLabels));
-			printf("\nMax memory allocation size:  %llu Mb", device->getMaxMemoryAllocationSize()>>20); // cryo::util::formatValue(device->getMaxMemoryAllocationSize() >> 10, sizeUnits, sizeLabels));
-			printf("\nMax work group size:         %u", device->getMaxWorkGroupSize());
-			printf("\nLocal memory size:           %llu Kb", device->getLocalMemorySize()>>10);// cryo::util::formatValue(device->getLocalMemorySize() >> 10, sizeUnits, sizeLabels));
+std::size_t i = 0;
+for (const std::shared_ptr<OpenclDevice>& device : devices) {
+printf("\n----");
+printf("\nId:                          %u", i++);
+printf("\nType:                        %s", device->getType().c_str());
+printf("\nName:                        %s", device->getName().c_str());
+printf("\nVendor:                      %s", device->getVendor().c_str());
+printf("\nVersion:                     %s", device->getVersion().c_str());
+printf("\nDriver version:              %s", device->getDriverVersion().c_str());
+printf("\nMax clock frequency:         %u Mhz", device->getMaxClockFrequency());
+printf("\nMax compute units:           %u", device->getMaxComputeUnits());
+printf("\nGlobal memory size:          %llu Mb", device->getGlobalMemorySize()>>20); //cryo::util::formatValue(device->getGlobalMemorySize() >> 10, sizeUnits, sizeLabels));
+printf("\nMax memory allocation size:  %llu Mb", device->getMaxMemoryAllocationSize()>>20); // cryo::util::formatValue(device->getMaxMemoryAllocationSize() >> 10, sizeUnits, sizeLabels));
+printf("\nMax work group size:         %u", device->getMaxWorkGroupSize());
+printf("\nLocal memory size:           %llu Kb", device->getLocalMemorySize()>>10);// cryo::util::formatValue(device->getLocalMemorySize() >> 10, sizeUnits, sizeLabels));
 
-			std::vector<std::size_t> maxWorkItemSizes(device->getMaxWorkItemSizes());
-			//printf("\nMax work-item sizes:         (" << cryo::util::join(maxWorkItemSizes.begin(), maxWorkItemSizes.end(), ", ") << ")" << std::endl;
-			printf("\n----");
-		}
-	}
-	catch (const OpenclError& ex) {
-		printf("\n[ERROR][%u][%s] %s", ex.getCode(), ex.getCodeString().c_str(), ex.what());
-		return -1;
-	}
-	catch (const std::exception& ex) {
-		printf("\n[ERROR] %s", ex.what());
-		return -1;
-	}
-	
-	return 0;
+std::vector<std::size_t> maxWorkItemSizes(device->getMaxWorkItemSizes());
+//printf("\nMax work-item sizes:         (" << cryo::util::join(maxWorkItemSizes.begin(), maxWorkItemSizes.end(), ", ") << ")" << std::endl;
+printf("\n----");
+}
+}
+catch (const OpenclError& ex) {
+printf("\n[ERROR][%u][%s] %s", ex.getCode(), ex.getCodeString().c_str(), ex.what());
+return -1;
+}
+catch (const std::exception& ex) {
+printf("\n[ERROR] %s", ex.what());
+return -1;
+}
+
+return 0;
 }
 
 
@@ -2492,259 +2500,259 @@ return 0;
 
 int GPU_init(void)
 {
-	cl_int ret_err = 0;
-	//cl_uint num_devices = 0;
-	cl_uint num_platforms = 0;
+cl_int ret_err = 0;
+//cl_uint num_devices = 0;
+cl_uint num_platforms = 0;
 
-	//gpu_devices;
+//gpu_devices;
 
-	wprintw(win_main, "\nInit GPU platform and devices:");
-	wrefresh(win_main);
-	ret_err = clGetPlatformIDs(1, nullptr, &num_platforms);
-	if (CL_SUCCESS == ret_err)
-	{
-		wprintw(win_main, "\n Detected OpenCL platforms: %d", num_platforms);
-		if (num_platforms < (cl_uint)gpu_devices.use_gpu_platform+1)
-		{
-			wattron(win_main, COLOR_PAIR(12));
-			wprintw(win_main, "\nError. Set correct gpu_platform");
-			wattroff(win_main, COLOR_PAIR(12));
-			wrefresh(win_main);
-			return -1;
-		}
-	}
-	else
-	{
-		wattron(win_main, COLOR_PAIR(12)); 
-		wprintw(win_main, "\nError calling clGetPlatformIDs. Error code: %d", ret_err);
-		wattroff(win_main, COLOR_PAIR(12));
-		wrefresh(win_main);
-		return -1;
-	}
+wprintw(win_main, "\nInit GPU platform and devices:");
+wrefresh(win_main);
+ret_err = clGetPlatformIDs(1, nullptr, &num_platforms);
+if (CL_SUCCESS == ret_err)
+{
+wprintw(win_main, "\n Detected OpenCL platforms: %d", num_platforms);
+if (num_platforms < (cl_uint)gpu_devices.use_gpu_platform+1)
+{
+wattron(win_main, COLOR_PAIR(12));
+wprintw(win_main, "\nError. Set correct gpu_platform");
+wattroff(win_main, COLOR_PAIR(12));
+wrefresh(win_main);
+return -1;
+}
+}
+else
+{
+wattron(win_main, COLOR_PAIR(12));
+wprintw(win_main, "\nError calling clGetPlatformIDs. Error code: %d", ret_err);
+wattroff(win_main, COLOR_PAIR(12));
+wrefresh(win_main);
+return -1;
+}
 
-	cl_platform_id *platforms = (cl_platform_id*)calloc((size_t)num_platforms, sizeof(cl_platform_id));
-	if (platforms == nullptr) ShowMemErrorExit();
+cl_platform_id *platforms = (cl_platform_id*)calloc((size_t)num_platforms, sizeof(cl_platform_id));
+if (platforms == nullptr) ShowMemErrorExit();
 
-	ret_err = clGetPlatformIDs(num_platforms, platforms, &num_platforms);
-	if (ret_err != CL_SUCCESS)
-	{
-		wattron(win_main, COLOR_PAIR(12));
-		wprintw(win_main, "\n clGetPlatformIDs (error %i)", ret_err);
-		wattroff(win_main, COLOR_PAIR(12));
-		wrefresh(win_main);
-		free(platforms);
-		return -1;
-	}
+ret_err = clGetPlatformIDs(num_platforms, platforms, &num_platforms);
+if (ret_err != CL_SUCCESS)
+{
+wattron(win_main, COLOR_PAIR(12));
+wprintw(win_main, "\n clGetPlatformIDs (error %i)", ret_err);
+wattroff(win_main, COLOR_PAIR(12));
+wrefresh(win_main);
+free(platforms);
+return -1;
+}
 
 
-	ret_err = clGetDeviceIDs(platforms[gpu_devices.use_gpu_platform], CL_DEVICE_TYPE_GPU, 0, nullptr, &gpu_devices.num_devices);
-	if (CL_SUCCESS == ret_err)
-	{
-		char *str_info_platform = (char*)calloc(255, sizeof(char));
-		ret_err = clGetPlatformInfo(platforms[gpu_devices.use_gpu_platform], CL_PLATFORM_VERSION, 254, str_info_platform, nullptr);
-		wprintw(win_main, "\n Platform #%d: %s\n  Detected GPU devices: %llu", (cl_uint)gpu_devices.use_gpu_platform, str_info_platform, gpu_devices.num_devices, 0);
-		free(str_info_platform);
-		if (gpu_devices.num_devices < (cl_uint)gpu_devices.use_gpu_device + 1)
-		{
-			wattron(win_main, COLOR_PAIR(12));
-			wprintw(win_main, "\nError. Set correct gpu_device");
-			wattroff(win_main, COLOR_PAIR(12));
-			wrefresh(win_main);
-			free(platforms);
-			return -2;
-		}
-	}
-	else
-	{
-		wattron(win_main, COLOR_PAIR(12));
-		wprintw(win_main, "\nError calling clGetDeviceIDs. Error code: %d", ret_err);
-		wattroff(win_main, COLOR_PAIR(12));
-		wrefresh(win_main);
-		free(platforms);
-		return -2;
-	}
+ret_err = clGetDeviceIDs(platforms[gpu_devices.use_gpu_platform], CL_DEVICE_TYPE_GPU, 0, nullptr, &gpu_devices.num_devices);
+if (CL_SUCCESS == ret_err)
+{
+char *str_info_platform = (char*)calloc(255, sizeof(char));
+ret_err = clGetPlatformInfo(platforms[gpu_devices.use_gpu_platform], CL_PLATFORM_VERSION, 254, str_info_platform, nullptr);
+wprintw(win_main, "\n Platform #%d: %s\n  Detected GPU devices: %llu", (cl_uint)gpu_devices.use_gpu_platform, str_info_platform, gpu_devices.num_devices, 0);
+free(str_info_platform);
+if (gpu_devices.num_devices < (cl_uint)gpu_devices.use_gpu_device + 1)
+{
+wattron(win_main, COLOR_PAIR(12));
+wprintw(win_main, "\nError. Set correct gpu_device");
+wattroff(win_main, COLOR_PAIR(12));
+wrefresh(win_main);
+free(platforms);
+return -2;
+}
+}
+else
+{
+wattron(win_main, COLOR_PAIR(12));
+wprintw(win_main, "\nError calling clGetDeviceIDs. Error code: %d", ret_err);
+wattroff(win_main, COLOR_PAIR(12));
+wrefresh(win_main);
+free(platforms);
+return -2;
+}
 
-	gpu_devices.devices = (cl_device_id*)calloc((size_t)gpu_devices.num_devices, sizeof(cl_device_id));
-	if (gpu_devices.devices == nullptr) 
-	{
-		free(platforms);
-		ShowMemErrorExit();
-		return -2;
-	}
+gpu_devices.devices = (cl_device_id*)calloc((size_t)gpu_devices.num_devices, sizeof(cl_device_id));
+if (gpu_devices.devices == nullptr)
+{
+free(platforms);
+ShowMemErrorExit();
+return -2;
+}
 
-	ret_err	= clGetDeviceIDs(platforms[gpu_devices.use_gpu_platform], CL_DEVICE_TYPE_GPU, gpu_devices.num_devices, gpu_devices.devices, &gpu_devices.num_devices);
-	if (ret_err != CL_SUCCESS)
-	{
-		wattron(win_main, COLOR_PAIR(12));
-		wprintw(win_main, "\n clGetDeviceIDs (error %i)", gpu_devices.num_devices, ret_err);
-		wattroff(win_main, COLOR_PAIR(12));
-		wrefresh(win_main);
-		free(platforms);
-		return -2;
-	}
+ret_err	= clGetDeviceIDs(platforms[gpu_devices.use_gpu_platform], CL_DEVICE_TYPE_GPU, gpu_devices.num_devices, gpu_devices.devices, &gpu_devices.num_devices);
+if (ret_err != CL_SUCCESS)
+{
+wattron(win_main, COLOR_PAIR(12));
+wprintw(win_main, "\n clGetDeviceIDs (error %i)", gpu_devices.num_devices, ret_err);
+wattroff(win_main, COLOR_PAIR(12));
+wrefresh(win_main);
+free(platforms);
+return -2;
+}
 
-	ret_err = clGetDeviceInfo(gpu_devices.devices[gpu_devices.use_gpu_device], CL_DEVICE_MAX_WORK_GROUP_SIZE, sizeof(size_t), &gpu_devices.max_WorkGroupSize, nullptr);
+ret_err = clGetDeviceInfo(gpu_devices.devices[gpu_devices.use_gpu_device], CL_DEVICE_MAX_WORK_GROUP_SIZE, sizeof(size_t), &gpu_devices.max_WorkGroupSize, nullptr);
 
-	ret_err = clGetDeviceInfo(gpu_devices.devices[gpu_devices.use_gpu_device], CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(size_t), &gpu_devices.max_ComputeUnits, nullptr);
+ret_err = clGetDeviceInfo(gpu_devices.devices[gpu_devices.use_gpu_device], CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(size_t), &gpu_devices.max_ComputeUnits, nullptr);
 
-	char *str_info_1 = (char*)calloc(255, sizeof(char));
-	ret_err = clGetDeviceInfo(gpu_devices.devices[gpu_devices.use_gpu_device], CL_DEVICE_NAME, 254, str_info_1, nullptr);
+char *str_info_1 = (char*)calloc(255, sizeof(char));
+ret_err = clGetDeviceInfo(gpu_devices.devices[gpu_devices.use_gpu_device], CL_DEVICE_NAME, 254, str_info_1, nullptr);
 
-	char *str_info_2 = (char*)calloc(255, sizeof(char));
-	ret_err = clGetDeviceInfo(gpu_devices.devices[gpu_devices.use_gpu_device], CL_DEVICE_VERSION, 254, str_info_2, nullptr);
-	wprintw(win_main, "\n  Device: %s, %s, %u", str_info_1, str_info_2, gpu_devices.max_ComputeUnits);
-	wrefresh(win_main);
-	free(str_info_1);
-	free(str_info_2);
+char *str_info_2 = (char*)calloc(255, sizeof(char));
+ret_err = clGetDeviceInfo(gpu_devices.devices[gpu_devices.use_gpu_device], CL_DEVICE_VERSION, 254, str_info_2, nullptr);
+wprintw(win_main, "\n  Device: %s, %s, %u", str_info_1, str_info_2, gpu_devices.max_ComputeUnits);
+wrefresh(win_main);
+free(str_info_1);
+free(str_info_2);
 
-	free(platforms);
-	return 0;
+free(platforms);
+return 0;
 }
 
 int GPU1(void)
 {
-	const unsigned int HASH_SIZE = 32;
-	const unsigned int HASHES_PER_SCOOP = 2;
-	const unsigned int SCOOP_SIZE = HASHES_PER_SCOOP * HASH_SIZE;
-	const unsigned int SCOOPS_PER_PLOT = 4096;
-	const unsigned int PLOT_SIZE = SCOOPS_PER_PLOT * SCOOP_SIZE;
-	const unsigned int HASH_CAP = 4096;
-	const unsigned int GEN_SIZE = PLOT_SIZE + 16;
-	unsigned int WorkSize = 64;
-	
-	cl_context context;
-	cl_command_queue commandQueue;
-	cl_mem bufferDevice;
-		
-	FILE* programHandle;
-	size_t programSize; 
-	char *programBuffer;
-	cl_program program;
-	
-	cl_int ret_err = 0;
+const unsigned int HASH_SIZE = 32;
+const unsigned int HASHES_PER_SCOOP = 2;
+const unsigned int SCOOP_SIZE = HASHES_PER_SCOOP * HASH_SIZE;
+const unsigned int SCOOPS_PER_PLOT = 4096;
+const unsigned int PLOT_SIZE = SCOOPS_PER_PLOT * SCOOP_SIZE;
+const unsigned int HASH_CAP = 4096;
+const unsigned int GEN_SIZE = PLOT_SIZE + 16;
+unsigned int WorkSize = 64;
+
+cl_context context;
+cl_command_queue commandQueue;
+cl_mem bufferDevice;
+
+FILE* programHandle;
+size_t programSize;
+char *programBuffer;
+cl_program program;
+
+cl_int ret_err = 0;
 
 
-	context = clCreateContext(nullptr, gpu_devices.num_devices, gpu_devices.devices, nullptr, nullptr, &ret_err);
-	wprintw(win_main, "\nclCreateContext (error %i)", ret_err);
-	wrefresh(win_main);
+context = clCreateContext(nullptr, gpu_devices.num_devices, gpu_devices.devices, nullptr, nullptr, &ret_err);
+wprintw(win_main, "\nclCreateContext (error %i)", ret_err);
+wrefresh(win_main);
 
-	commandQueue = clCreateCommandQueue(context, gpu_devices.devices[gpu_devices.use_gpu_device], 0, &ret_err);
-	wprintw(win_main, "\nclCreateCommandQueue (error %i)", ret_err);
-	wrefresh(win_main);
+commandQueue = clCreateCommandQueue(context, gpu_devices.devices[gpu_devices.use_gpu_device], 0, &ret_err);
+wprintw(win_main, "\nclCreateCommandQueue (error %i)", ret_err);
+wrefresh(win_main);
 
-	bufferDevice = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(unsigned char)* WorkSize * GEN_SIZE, 0, &ret_err);
-	wprintw(win_main, "\nclCreateBuffer (error %i)", ret_err);
-	wrefresh(win_main);
+bufferDevice = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(unsigned char)* WorkSize * GEN_SIZE, 0, &ret_err);
+wprintw(win_main, "\nclCreateBuffer (error %i)", ret_err);
+wrefresh(win_main);
 
-	wprintw(win_main, "\nget size of kernel source: ");
-	// get size of kernel source
-	programHandle = fopen("calcdeadlines.cl", "rb");
-	_fseeki64(programHandle, 0, SEEK_END);
-	programSize = _ftelli64(programHandle);
-	rewind(programHandle);
-	wprintw(win_main, "%Iu", programSize);
-	wrefresh(win_main);
+wprintw(win_main, "\nget size of kernel source: ");
+// get size of kernel source
+programHandle = fopen("calcdeadlines.cl", "rb");
+_fseeki64(programHandle, 0, SEEK_END);
+programSize = _ftelli64(programHandle);
+rewind(programHandle);
+wprintw(win_main, "%Iu", programSize);
+wrefresh(win_main);
 
-	wprintw(win_main, "\nread kernel source into buffer");
-	// read kernel source into buffer
-	programBuffer = (char*)calloc(programSize+1, sizeof(char));
-	programBuffer[programSize] = '\0';
-	fread(programBuffer, sizeof(char), programSize, programHandle);
-	fclose(programHandle);
-	wrefresh(win_main);
+wprintw(win_main, "\nread kernel source into buffer");
+// read kernel source into buffer
+programBuffer = (char*)calloc(programSize+1, sizeof(char));
+programBuffer[programSize] = '\0';
+fread(programBuffer, sizeof(char), programSize, programHandle);
+fclose(programHandle);
+wrefresh(win_main);
 
-	wprintw(win_main, "\ncreate program from buffer");
-	// create program from buffer
-	program = clCreateProgramWithSource(context, 1,	(const char**)&programBuffer, &programSize, &ret_err);
-	free(programBuffer);
-	wprintw(win_main, " (error %i)", ret_err);
-	wrefresh(win_main);
+wprintw(win_main, "\ncreate program from buffer");
+// create program from buffer
+program = clCreateProgramWithSource(context, 1,	(const char**)&programBuffer, &programSize, &ret_err);
+free(programBuffer);
+wprintw(win_main, " (error %i)", ret_err);
+wrefresh(win_main);
 
-	wprintw(win_main, "\nbuild program");
-	// build program
-	
-	char *opt = (char*)calloc(strlen(p_minerPath)+12, sizeof(char));
-	opt = strcat(opt, "-I ");
-	opt = strcat(opt, p_minerPath);
-	opt = strcat(opt, " -Werror");
-	wprintw(win_main, "\n%s", opt);
-	wrefresh(win_main);
-	
-	ret_err = clBuildProgram(program, 1, gpu_devices.devices, opt, nullptr, nullptr);
-	wprintw(win_main, "\nclBuildProgram %d", ret_err);
-	wrefresh(win_main);
-	free(opt);
-	// build failed
-	if (ret_err != CL_SUCCESS) {
-		cl_build_status status;
-		size_t logSize;
+wprintw(win_main, "\nbuild program");
+// build program
 
-		wprintw(win_main, "\nbuild ERROR");
-		wrefresh(win_main);
-		// check build error and build status first
-		clGetProgramBuildInfo(program, gpu_devices.devices[gpu_devices.use_gpu_device], CL_PROGRAM_BUILD_STATUS, sizeof(cl_build_status), &status, nullptr);
-		wprintw(win_main, "\nCL_PROGRAM_BUILD_STATUS",0);
-		wrefresh(win_main);
-		// check build log
-		clGetProgramBuildInfo(program, gpu_devices.devices[gpu_devices.use_gpu_device], CL_PROGRAM_BUILD_LOG, 0, nullptr, &logSize);
-		wprintw(win_main, "\nCL_PROGRAM_BUILD_LOG %Iu", logSize);
-		wrefresh(win_main);
-		char *programLog = (char*)calloc(logSize + 1, sizeof(char));
-		clGetProgramBuildInfo(program, gpu_devices.devices[gpu_devices.use_gpu_device], CL_PROGRAM_BUILD_LOG, logSize, programLog, &logSize);
-		wprintw(win_main, "\nCL_PROGRAM_BUILD_LOG");
-		programLog[475] = 0;
-		wprintw(win_main, "\nBuild failed: error=%d, status=%d, programLog:\n%s", ret_err, status, programLog);
-		wrefresh(win_main);
-		free(programLog);
-		
-	}
-	
-	//cl_kernel kernel[3];
-	cl_kernel *kernels = (cl_kernel*)calloc(3, sizeof(cl_kernel));
-	kernels[0] = clCreateKernel(program, "calculate_deadlines", &ret_err);
-	wprintw(win_main, "\nclCreateKernel_1 %d", ret_err);
-	wrefresh(win_main);
+char *opt = (char*)calloc(strlen(p_minerPath)+12, sizeof(char));
+opt = strcat(opt, "-I ");
+opt = strcat(opt, p_minerPath);
+opt = strcat(opt, " -Werror");
+wprintw(win_main, "\n%s", opt);
+wrefresh(win_main);
 
-	//size_t lwg = 0;
-	//ret_err = clGetKernelWorkGroupInfo(kernels[0], gpu_devices.devices[gpu_devices.use_gpu_device], CL_KERNEL_WORK_GROUP_SIZE, sizeof(lwg), (void*)&lwg, nullptr);
-	//wprintw(win_main, "\nlocal WGS %llu", lwg);
-	//wrefresh(win_main);
+ret_err = clBuildProgram(program, 1, gpu_devices.devices, opt, nullptr, nullptr);
+wprintw(win_main, "\nclBuildProgram %d", ret_err);
+wrefresh(win_main);
+free(opt);
+// build failed
+if (ret_err != CL_SUCCESS) {
+cl_build_status status;
+size_t logSize;
 
-	ret_err = clSetKernelArg(kernels[0], 0, sizeof(cl_mem), (void*)&bufferDevice);
-	wprintw(win_main, "\nclSetKernelArg_1 %d", ret_err);
-	wrefresh(win_main);
+wprintw(win_main, "\nbuild ERROR");
+wrefresh(win_main);
+// check build error and build status first
+clGetProgramBuildInfo(program, gpu_devices.devices[gpu_devices.use_gpu_device], CL_PROGRAM_BUILD_STATUS, sizeof(cl_build_status), &status, nullptr);
+wprintw(win_main, "\nCL_PROGRAM_BUILD_STATUS",0);
+wrefresh(win_main);
+// check build log
+clGetProgramBuildInfo(program, gpu_devices.devices[gpu_devices.use_gpu_device], CL_PROGRAM_BUILD_LOG, 0, nullptr, &logSize);
+wprintw(win_main, "\nCL_PROGRAM_BUILD_LOG %Iu", logSize);
+wrefresh(win_main);
+char *programLog = (char*)calloc(logSize + 1, sizeof(char));
+clGetProgramBuildInfo(program, gpu_devices.devices[gpu_devices.use_gpu_device], CL_PROGRAM_BUILD_LOG, logSize, programLog, &logSize);
+wprintw(win_main, "\nCL_PROGRAM_BUILD_LOG");
+programLog[475] = 0;
+wprintw(win_main, "\nBuild failed: error=%d, status=%d, programLog:\n%s", ret_err, status, programLog);
+wrefresh(win_main);
+free(programLog);
 
-	kernels[1] = clCreateKernel(program, "reduce_best", &ret_err);
-	wprintw(win_main, "\nclCreateKernel_2 %d", ret_err);
-	wrefresh(win_main);
+}
 
-	ret_err = clSetKernelArg(kernels[1], 0, sizeof(cl_mem), (void*)&bufferDevice);
-	wprintw(win_main, "\nclSetKernelArg_2 %d", ret_err);
-	wrefresh(win_main);
+//cl_kernel kernel[3];
+cl_kernel *kernels = (cl_kernel*)calloc(3, sizeof(cl_kernel));
+kernels[0] = clCreateKernel(program, "calculate_deadlines", &ret_err);
+wprintw(win_main, "\nclCreateKernel_1 %d", ret_err);
+wrefresh(win_main);
 
-	kernels[2] = clCreateKernel(program, "reduce_target", &ret_err);
-	wprintw(win_main, "\nclCreateKernel_3 %d", ret_err);
-	wrefresh(win_main);
+//size_t lwg = 0;
+//ret_err = clGetKernelWorkGroupInfo(kernels[0], gpu_devices.devices[gpu_devices.use_gpu_device], CL_KERNEL_WORK_GROUP_SIZE, sizeof(lwg), (void*)&lwg, nullptr);
+//wprintw(win_main, "\nlocal WGS %llu", lwg);
+//wrefresh(win_main);
 
-	ret_err = clSetKernelArg(kernels[2], 0, sizeof(cl_mem), (void*)&bufferDevice);
-	wprintw(win_main, "\nclSetKernelArg_3 %d", ret_err);
-	wrefresh(win_main);
-	
+ret_err = clSetKernelArg(kernels[0], 0, sizeof(cl_mem), (void*)&bufferDevice);
+wprintw(win_main, "\nclSetKernelArg_1 %d", ret_err);
+wrefresh(win_main);
 
+kernels[1] = clCreateKernel(program, "reduce_best", &ret_err);
+wprintw(win_main, "\nclCreateKernel_2 %d", ret_err);
+wrefresh(win_main);
+
+ret_err = clSetKernelArg(kernels[1], 0, sizeof(cl_mem), (void*)&bufferDevice);
+wprintw(win_main, "\nclSetKernelArg_2 %d", ret_err);
+wrefresh(win_main);
+
+kernels[2] = clCreateKernel(program, "reduce_target", &ret_err);
+wprintw(win_main, "\nclCreateKernel_3 %d", ret_err);
+wrefresh(win_main);
+
+ret_err = clSetKernelArg(kernels[2], 0, sizeof(cl_mem), (void*)&bufferDevice);
+wprintw(win_main, "\nclSetKernelArg_3 %d", ret_err);
+wrefresh(win_main);
 
 
-	free(gpu_devices.devices);
-	if (kernels[2]) { clReleaseKernel(kernels[2]); }
-	if (kernels[1]) { clReleaseKernel(kernels[1]); }
-	if (kernels[0]) { clReleaseKernel(kernels[0]); }
-	
-	if (program) { clReleaseProgram(program); }
-	if (bufferDevice) { clReleaseMemObject(bufferDevice); }
-	if (commandQueue) { clReleaseCommandQueue(commandQueue); }
-	if (context) { clReleaseContext(context); }
-	wprintw(win_main, "\n--\n");
-	wrefresh(win_main);
-	return 0;
+
+
+free(gpu_devices.devices);
+if (kernels[2]) { clReleaseKernel(kernels[2]); }
+if (kernels[1]) { clReleaseKernel(kernels[1]); }
+if (kernels[0]) { clReleaseKernel(kernels[0]); }
+
+if (program) { clReleaseProgram(program); }
+if (bufferDevice) { clReleaseMemObject(bufferDevice); }
+if (commandQueue) { clReleaseCommandQueue(commandQueue); }
+if (context) { clReleaseContext(context); }
+wprintw(win_main, "\n--\n");
+wrefresh(win_main);
+return 0;
 }
 
 #endif
@@ -2796,7 +2804,7 @@ int main(int argc, char **argv) {
 		system("pause");
 		exit(-1);
 	}
-	if ((argc >= 2) && (strcmp(argv[1], "-config") == 0)){
+	if ((argc >= 2) && (strcmp(argv[1], "-config") == 0)) {
 		if (strstr(argv[2], ":\\")) sprintf_s(conf_filename, MAX_PATH, "%s", argv[2]);
 		else sprintf_s(conf_filename, MAX_PATH, "%s%s", p_minerPath, argv[2]);
 	}
@@ -2923,12 +2931,12 @@ int main(int argc, char **argv) {
 
 	std::vector<t_files> all_files;
 	total_size = 0;
-	for (auto iter = paths_dir.begin(); iter != paths_dir.end(); ++iter)	{
+	for (auto iter = paths_dir.begin(); iter != paths_dir.end(); ++iter) {
 		std::vector<t_files> files;
 		GetFiles(*iter, &files);
 
 		unsigned long long tot_size = 0;
-		for (auto it = files.begin(); it != files.end(); ++it){
+		for (auto it = files.begin(); it != files.end(); ++it) {
 			tot_size += it->Size;
 			all_files.push_back(*it);
 		}
@@ -2949,18 +2957,18 @@ int main(int argc, char **argv) {
 	}
 
 	// Check overlapped plots
-	for (size_t cx = 0; cx < all_files.size(); cx++)	{
-		for (size_t cy = cx + 1; cy < all_files.size(); cy++)		{
+	for (size_t cx = 0; cx < all_files.size(); cx++) {
+		for (size_t cy = cx + 1; cy < all_files.size(); cy++) {
 			if (all_files[cy].Key == all_files[cx].Key)
 				if (all_files[cy].StartNonce >= all_files[cx].StartNonce) {
-					if (all_files[cy].StartNonce < all_files[cx].StartNonce + all_files[cx].Nonces){
+					if (all_files[cy].StartNonce < all_files[cx].StartNonce + all_files[cx].Nonces) {
 						wattron(win_main, COLOR_PAIR(12));
 						wprintw(win_main, "\nWARNING: %s%s and \n%s%s are overlapped\n", all_files[cx].Path.c_str(), all_files[cx].Name.c_str(), all_files[cy].Path.c_str(), all_files[cy].Name.c_str(), 0);
 						wattroff(win_main, COLOR_PAIR(12));
 					}
 				}
 				else
-					if (all_files[cy].StartNonce + all_files[cy].Nonces > all_files[cx].StartNonce){
+					if (all_files[cy].StartNonce + all_files[cy].Nonces > all_files[cx].StartNonce) {
 						wattron(win_main, COLOR_PAIR(12));
 						wprintw(win_main, "\nWARNING: %s%s and \n%s%s are overlapped\n", all_files[cx].Path.c_str(), all_files[cx].Name.c_str(), all_files[cy].Path.c_str(), all_files[cy].Name.c_str(), 0);
 						wattroff(win_main, COLOR_PAIR(12));
@@ -2989,14 +2997,14 @@ int main(int argc, char **argv) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(2));
 	};
 
-	
+
 	// Main loop
 	for (; !exit_flag;)
 	{
 		worker.clear();
 		worker_progress.clear();
 		stopThreads = 0;
-		
+
 		char scoopgen[40];
 		memmove(scoopgen, signature, 32);
 		const char *mov = (char*)&height;
@@ -3015,10 +3023,10 @@ int main(int argc, char **argv) {
 
 
 		Log("\n------------------------    New block: "); Log_llu(height);
-		
+
 		_strtime_s(tbuffer);
 		wattron(win_main, COLOR_PAIR(25));
-		wprintw(win_main, "\n%s New block %llu, baseTarget %llu, netDiff %llu Tb, POC%i      \n", tbuffer, height, baseTarget, 4398046511104 / 240 / baseTarget, POC2 ? 2 : 1,0);
+		wprintw(win_main, "\n%s New block %llu, baseTarget %llu, netDiff %llu Tb, POC%i      \n", tbuffer, height, baseTarget, 4398046511104 / 240 / baseTarget, POC2 ? 2 : 1, 0);
 		wattron(win_main, COLOR_PAIR(25));
 		if (miner_mode == 0)
 		{
@@ -3040,7 +3048,7 @@ int main(int argc, char **argv) {
 		bests.clear();
 		LeaveCriticalSection(&bestsLock);
 
-		if ((targetDeadlineInfo > 0) && (targetDeadlineInfo < my_target_deadline)){
+		if ((targetDeadlineInfo > 0) && (targetDeadlineInfo < my_target_deadline)) {
 			Log("\nUpdate targetDeadline: "); Log_llu(targetDeadlineInfo);
 		}
 		else targetDeadlineInfo = my_target_deadline;
@@ -3051,7 +3059,7 @@ int main(int argc, char **argv) {
 		// Run Threads
 		QueryPerformanceCounter((LARGE_INTEGER*)&start_threads_time);
 		double threads_speed = 0;
-		
+
 		for (size_t i = 0; i < paths_dir.size(); i++)
 		{
 			worker_progress.push_back({ i, 0, true });
@@ -3075,7 +3083,7 @@ int main(int argc, char **argv) {
 				break;
 			case 'r':
 				wattron(win_main, COLOR_PAIR(15));
-				wprintw(win_main, "Recommended size for this block: %llu Gb\n", (4398046511104 / baseTarget)*1024 / targetDeadlineInfo);
+				wprintw(win_main, "Recommended size for this block: %llu Gb\n", (4398046511104 / baseTarget) * 1024 / targetDeadlineInfo);
 				wattroff(win_main, COLOR_PAIR(15));
 				break;
 			case 'c':
@@ -3097,13 +3105,13 @@ int main(int argc, char **argv) {
 				QueryPerformanceCounter((LARGE_INTEGER*)&end_threads_time);
 				threads_speed = (double)(bytesRead / (1024 * 1024)) / ((double)(end_threads_time - start_threads_time) / pcFreq);
 			}
-			else{
+			else {
 				/*
 				if (can_generate == 1)
 				{
-					Log("\nStart Generator. ");
-					for (size_t i = 0; i < std::thread::hardware_concurrency()-1; i++)	generator.push_back(std::thread(generator_i, i));
-					can_generate = 2;
+				Log("\nStart Generator. ");
+				for (size_t i = 0; i < std::thread::hardware_concurrency()-1; i++)	generator.push_back(std::thread(generator_i, i));
+				can_generate = 2;
 				}
 				*/
 				if (use_wakeup)
@@ -3153,18 +3161,18 @@ int main(int argc, char **argv) {
 
 		Log("\nInterrupt Sender. ");
 		if (sender.joinable()) sender.join();
-		
+
 		/*
 		if (can_generate != 0){
-			Log("\nInterrupt Generator. ");
-			for (auto it = generator.begin(); it != generator.end(); ++it){
-				if (it->joinable()) it->join();
-			}
-			can_generate = 1;
+		Log("\nInterrupt Generator. ");
+		for (auto it = generator.begin(); it != generator.end(); ++it){
+		if (it->joinable()) it->join();
+		}
+		can_generate = 1;
 		}
 		*/
 
-		
+
 		fopen_s(&pFileStat, "stat.csv", "a+t");
 		if (pFileStat != nullptr)
 		{


### PR DESCRIPTION
me again =) optimized the shuffle mechanism. Rather then reading (front scoop, back scoop, repeat), it is now reading (front scoop, back scoop, back scoop, front scoop, repeat). Saves ~50% of the hdd seeks and improves scanning time. Also requires less memory, CacheSize2 setting to be halved to preserve maximum speed. Using 500k maximizes my read speed.